### PR TITLE
/clock out

### DIFF
--- a/src/classes/ClockResourceTest.cls
+++ b/src/classes/ClockResourceTest.cls
@@ -115,6 +115,117 @@ private class ClockResourceTest {
         System.assertEquals(SlashclockService.ALREADY_CLOCKED_IN_ERROR, commandRes.text,
                 'SlashCommandResponse.text');
     }
+    
+    /**
+     * - Given a Slack user who is not clocked in;
+     * - When the Slack user types /clock in;
+     * - Then a new Time Entry record should be created for the user,
+     *   and a confirmation message sent to user saying, "You're clocked in."
+     */
+    @isTest
+    private static void clockOutSuccess() {
+
+        // Given
+        String userId = 'flip';
+        String teamId = 'board';
+
+        List<TimeEntry__c> openEntries = [
+            SELECT Id, StartTime__c
+            FROM TimeEntry__c
+            WHERE SlackUserId__c = :userId
+                AND SlackTeamId__c = :teamId
+                AND EndTime__c = NULL
+        ];
+
+        System.assertEquals(1, openEntries.size(),
+                'existing time entry expected');
+
+        // When
+        Test.startTest();
+
+        RestRequest restReq = new RestRequest();
+        restReq.params.put(SlashCommandUtil.USER_ID_PARAM, userId);
+        restReq.params.put(SlashCommandUtil.TEAM_ID_PARAM, teamId);
+        restReq.params.put(SlashCommandUtil.COMMAND_PARAM, '/clock');
+        restReq.params.put(SlashCommandUtil.TEXT_PARAM, 'out');
+
+        RestContext.request = restReq;
+        RestContext.response = new RestResponse();
+
+        Slack.SlashCommandResponse commandRes = ClockResource.post();
+
+        // Then
+        Test.stopTest();
+
+        TimeEntry__c closedEntry = [
+            SELECT Id, StartTime__c, EndTime__c
+            FROM TimeEntry__c
+            WHERE Id = :openEntries[0].Id
+        ];
+
+        System.assert(closedEntry.EndTIme__c >= closedEntry.StartTime__c,
+                'entry end time should be after start time');
+
+        System.assertEquals(SlashclockService.CLOCKED_OUT_SUCCESS, commandRes.text,
+                'SlashCommandResponse.text');
+    }
+
+    /**
+     * - Given a Slack user who has already clocked in;
+     * - When the Slack user types /clock in;
+     * - Then the user should get an error message saying,
+     *   "Uh, you already clocked in earlier."
+     */
+    @isTest
+    private static void clockOutError() {
+
+        // Given
+        DateTime startTime = DateTime.now();
+        String userId = 'foo';
+        String teamId = 'bar';
+
+        List<TimeEntry__c> existingOpenEntries = [
+            SELECT Id, StartTime__c
+            FROM TimeEntry__c
+            WHERE SlackUserId__c = :userId
+                AND SlackTeamId__c = :teamId
+                AND EndTime__c = NULL
+        ];
+
+        System.assertEquals(0, existingOpenEntries.size(),
+                'no existing time entries expected');
+
+        // When
+        Test.startTest();
+
+        RestRequest restReq = new RestRequest();
+        restReq.params.put(SlashCommandUtil.USER_ID_PARAM, userId);
+        restReq.params.put(SlashCommandUtil.TEAM_ID_PARAM, teamId);
+        restReq.params.put(SlashCommandUtil.COMMAND_PARAM, '/clock');
+        restReq.params.put(SlashCommandUtil.TEXT_PARAM, 'out');
+
+        RestContext.request = restReq;
+        RestContext.response = new RestResponse();
+
+        Slack.SlashCommandResponse commandRes = ClockResource.post();
+
+        // Then
+        Test.stopTest();
+
+        List<TimeEntry__c> finalOpenEntries = [
+            SELECT Id, StartTime__c
+            FROM TimeEntry__c
+            WHERE SlackUserId__c = :userId
+                AND SlackTeamId__c = :teamId
+                AND EndTime__c = NULL
+        ];
+
+        System.assertEquals(0, finalOpenEntries.size(),
+                'no open time entries expected');
+
+        System.assertEquals(SlashclockService.NOT_CLOCKED_IN_ERROR, commandRes.text,
+                'SlashCommandResponse.text');
+    }
 
     @testSetup
     private static void setup() {

--- a/src/classes/ClockResourceTest.cls
+++ b/src/classes/ClockResourceTest.cls
@@ -117,10 +117,10 @@ private class ClockResourceTest {
     }
     
     /**
-     * - Given a Slack user who is not clocked in;
-     * - When the Slack user types /clock in;
-     * - Then a new Time Entry record should be created for the user,
-     *   and a confirmation message sent to user saying, "You're clocked in."
+     * - Given a Slack user who is clocked in;
+     * - When the Slack user types /clock out;
+     * - Then the open Time Entry record should be updated for the user,
+     *   and a confirmation message sent to user saying, "You have clocked out."
      */
     @isTest
     private static void clockOutSuccess() {
@@ -169,12 +169,70 @@ private class ClockResourceTest {
         System.assertEquals(SlashclockService.CLOCKED_OUT_SUCCESS, commandRes.text,
                 'SlashCommandResponse.text');
     }
+    
+    /**
+     * - Given a Slack user who is clocked in;
+     * - When the Slack user types "/clock out" twice;
+     * - Then the open Time Entry record should be closed for the user,
+     *   but the second message sent to user should say,
+     *   "You must first clock in!"
+     */
+    @isTest
+    private static void clockOutTwiceError() {
+
+        // Given
+        String userId = 'flip';
+        String teamId = 'board';
+
+        List<TimeEntry__c> openEntries = [
+            SELECT Id, StartTime__c
+            FROM TimeEntry__c
+            WHERE SlackUserId__c = :userId
+                AND SlackTeamId__c = :teamId
+                AND EndTime__c = NULL
+        ];
+
+        System.assertEquals(1, openEntries.size(),
+                'existing time entry expected');
+
+        // When
+        Test.startTest();
+
+        RestRequest restReq = new RestRequest();
+        restReq.params.put(SlashCommandUtil.USER_ID_PARAM, userId);
+        restReq.params.put(SlashCommandUtil.TEAM_ID_PARAM, teamId);
+        restReq.params.put(SlashCommandUtil.COMMAND_PARAM, '/clock');
+        restReq.params.put(SlashCommandUtil.TEXT_PARAM, 'out');
+
+        RestContext.request = restReq;
+        RestContext.response = new RestResponse();
+
+        Slack.SlashCommandResponse firstCommandRes = ClockResource.post();
+        Slack.SlashCommandResponse secondCommandRes = ClockResource.post();
+
+        // Then
+        Test.stopTest();
+
+        TimeEntry__c closedEntry = [
+            SELECT Id, StartTime__c, EndTime__c
+            FROM TimeEntry__c
+            WHERE Id = :openEntries[0].Id
+        ];
+
+        System.assert(closedEntry.EndTIme__c >= closedEntry.StartTime__c,
+                'entry end time should be after start time');
+
+        System.assertEquals(SlashclockService.CLOCKED_OUT_SUCCESS, firstCommandRes.text,
+                'SlashCommandResponse.text');
+        System.assertEquals(SlashclockService.NOT_CLOCKED_IN_ERROR, secondCommandRes.text,
+                'SlashCommandResponse.text');
+    }
 
     /**
-     * - Given a Slack user who has already clocked in;
-     * - When the Slack user types /clock in;
+     * - Given a Slack user who is not clocked in;
+     * - When the Slack user types /clock out;
      * - Then the user should get an error message saying,
-     *   "Uh, you already clocked in earlier."
+     *   "You must clock in first!"
      */
     @isTest
     private static void clockOutError() {

--- a/src/classes/SlashclockOutCommand.cls
+++ b/src/classes/SlashclockOutCommand.cls
@@ -1,0 +1,43 @@
+public with sharing class SlashclockOutCommand implements Slashclock.Command {
+
+    private DateTime endTime;
+    private String teamId;
+    private String userId;
+
+    public SlashclockOutCommand() {
+        this.userId = null;
+        this.teamId = null;
+        this.endTime = DateTime.now();
+    }
+
+    public Slashclock.CommandResult execute() {
+
+        // Initialize the result
+        Slashclock.CommandResult result = new Slashclock.CommandResult();
+
+        // Clock in via service
+        try {
+            SlashclockService slashclock =
+                    SlashclockService.getInstance(this.userId, this.teamId);
+            slashclock.clockOut(this.endTime);
+            result.setMessage(SlashclockService.CLOCKED_OUT_SUCCESS);
+            result.setSuccess(true);
+        }
+        catch (SlashclockException caught) {
+            result.setMessage(caught.getMessage());
+        }
+
+        // Return the result
+        return result;
+    }
+
+    public Slashclock.Command load(SlashCommand__c command) {
+        this.userId = command.SlackUserId__c;
+        this.teamId = command.SlackTeamId__c;
+        return this;
+    }
+
+    public Boolean matches(SlashCommand__c command) {
+        return command.Text__c.startsWith('out');
+    }
+}

--- a/src/classes/SlashclockOutCommand.cls-meta.xml
+++ b/src/classes/SlashclockOutCommand.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>39.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlashclockService.cls
+++ b/src/classes/SlashclockService.cls
@@ -6,6 +6,12 @@ public with sharing class SlashclockService {
     public static final String CLOCKED_IN_SUCCESS =
             'You have clocked in.';
 
+    public static final String CLOCKED_OUT_SUCCESS =
+            'You have clocked out.';
+
+    public static final String NOT_CLOCKED_IN_ERROR =
+            'You must clock in first!';
+
     /**
      * Slack Team ID
      */
@@ -42,6 +48,30 @@ public with sharing class SlashclockService {
 
         // Insert and return the time entry
         insert entry;
+        return entry;
+    }
+
+    /**
+     * @param endTime
+     *            The time at which the user clocked out
+     *
+     * @return updated time entry
+     */
+    public TimeEntry__c clockOut(DateTime endTime) {
+
+        // Look for existing open entries
+        List<TimeEntry__c> openTimeEntries = this.getOpenTimeEntries();
+        if (openTimeEntries.isEmpty()) {
+            throw new SlashclockException(NOT_CLOCKED_IN_ERROR);
+        }
+
+        // Update and return the open time entry.
+        // TODO: Handle edge case where multiple open entries exist.
+        TimeEntry__c entry =
+                openTimeEntries.get(openTimeEntries.size() - 1);
+        entry.EndTime__c = endTime;
+
+        update entry;
         return entry;
     }
 

--- a/src/classes/SlashclockService.cls
+++ b/src/classes/SlashclockService.cls
@@ -84,6 +84,7 @@ public with sharing class SlashclockService {
             FROM TimeEntry__c
             WHERE SlackUserId__c = :this.userId
                 AND SlackTeamId__c = :this.teamId
+                AND EndTime__c = NULL
         ];
     }
 

--- a/src/classes/SlashclockUtil.cls
+++ b/src/classes/SlashclockUtil.cls
@@ -1,7 +1,8 @@
 public with sharing class SlashclockUtil {
     public static List<Slashclock.Command> getKnownCommands() {
         return new List<Slashclock.Command> {
-            new SlashclockInCommand()
+            new SlashclockInCommand(),
+            new SlashclockOutCommand()
         };
     }
 

--- a/src/package.xml
+++ b/src/package.xml
@@ -12,6 +12,7 @@
 		<members>SlashclockUtil</members>
 		<members>ClockResourceTest</members>
 		<members>SlashclockInCommand</members>
+		<members>SlashclockOutCommand</members>
 		<name>ApexClass</name>
 	</types>
 	<types>


### PR DESCRIPTION
This pr implements `/clock out` such that it closes an open Time Entry record for the given user by stamping **End Time**. If the user tries to clock out without having already clocked in, an error message is returned.

![image](https://user-images.githubusercontent.com/6706834/29200582-9f48ce36-7e24-11e7-9f1a-243ebf9e08fe.png)