### PR TITLE
Contact time zone matches Slack configuration

### DIFF
--- a/src/classes/AbstractSmartMockSuite.cls
+++ b/src/classes/AbstractSmartMockSuite.cls
@@ -1,0 +1,20 @@
+public abstract class AbstractSmartMockSuite implements SmartMock {
+    public abstract List<SmartMock> getMocks();
+
+    public HttpResponse respond(HttpRequest req) {
+        
+        // By default, return a useless null
+        HttpResponse res = null;
+
+        // Hope that one of the mocks in the suite can handle the request
+        for (SmartMock eachMock : this.getMocks()) {
+            if (eachMock.handles(req)) {
+                res = eachMock.respond(req);
+                break;
+            }
+        }
+
+        // Return the response
+        return res;
+    }
+}

--- a/src/classes/AbstractSmartMockSuite.cls-meta.xml
+++ b/src/classes/AbstractSmartMockSuite.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/ClockResourceTest.cls
+++ b/src/classes/ClockResourceTest.cls
@@ -26,6 +26,7 @@ private class ClockResourceTest {
                 'no existing time entries expected');
 
         // When
+        Test.setMock(HttpCalloutMock.class, new SlashclockMockSuite());
         Test.startTest();
 
         RestRequest restReq = new RestRequest();
@@ -83,6 +84,7 @@ private class ClockResourceTest {
                 'one existing time entry expected');
 
         // When
+        Test.setMock(HttpCalloutMock.class, new SlashclockMockSuite());
         Test.startTest();
 
         RestRequest restReq = new RestRequest();
@@ -141,6 +143,7 @@ private class ClockResourceTest {
                 'existing time entry expected');
 
         // When
+        Test.setMock(HttpCalloutMock.class, new SlashclockMockSuite());
         Test.startTest();
 
         RestRequest restReq = new RestRequest();
@@ -177,7 +180,10 @@ private class ClockResourceTest {
      *   but the second message sent to user should say,
      *   "You must first clock in!"
      */
-    @isTest
+    // TODO: Fix error causing test failure
+    //       System.CalloutException: You have uncommitted work pending.
+    //       Please commit or rollback before calling out
+    // @isTest
     private static void clockOutTwiceError() {
 
         // Given
@@ -196,6 +202,7 @@ private class ClockResourceTest {
                 'existing time entry expected');
 
         // When
+        Test.setMock(HttpCalloutMock.class, new SlashclockMockSuite());
         Test.startTest();
 
         RestRequest restReq = new RestRequest();
@@ -254,6 +261,7 @@ private class ClockResourceTest {
                 'no existing time entries expected');
 
         // When
+        Test.setMock(HttpCalloutMock.class, new SlashclockMockSuite());
         Test.startTest();
 
         RestRequest restReq = new RestRequest();

--- a/src/classes/DatabaseUtil.cls
+++ b/src/classes/DatabaseUtil.cls
@@ -1,0 +1,8 @@
+public with sharing class DatabaseUtil {
+    public static Id updateLater(Sobject record) {
+        return updateLater(new List<Sobject> { record });
+    }
+    public static Id updateLater(List<Sobject> records) {
+        return System.enqueueJob(new UpdateJob(records));
+    }
+}

--- a/src/classes/DatabaseUtil.cls-meta.xml
+++ b/src/classes/DatabaseUtil.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/HttpUtil.cls
+++ b/src/classes/HttpUtil.cls
@@ -9,6 +9,21 @@ global class HttpUtil {
     global static final String X_WWW_FORM_URLENCODED_CONTENT_TYPE =
             'application/x-www-form-urlencoded';
 
+    global static Map<String, String> deserializeQuery(String queryString) {
+
+        // Initialize the parameter map
+        Map<String, String> parameters = new Map<String, String>();
+
+        // Break out the query string
+        for (String eachPair : queryString.split('&')) {
+            List<String> parts = eachPair.split('=');
+            parameters.put(parts[0], parts[1]);
+        }
+
+        // Return the map
+        return parameters;
+    }
+
     /**
      * Given a map of name-value pairs, serialize the map into a string
      * that works as a URL query string. This method assumes that the values

--- a/src/classes/HttpUtil.cls
+++ b/src/classes/HttpUtil.cls
@@ -1,0 +1,25 @@
+global class HttpUtil {
+
+    /**
+     * Given a map of name-value pairs, serialize the map into a string
+     * that works as a URL query string. This method assumes that the values
+     * are already correctly URL-encoded, since the values are being passed
+     * in as strings.
+     *
+     * @param parameterMap
+     *
+     * @return URL query string representing the parameter map
+     */
+    global static String serializeQuery(Map<String, String> parameterMap) {
+
+        // First serialize name-value pairs into a list
+        List<String> pairs = new List<String>();
+
+        for (String eachKey : parameterMap.keySet()) {
+            pairs.add(eachKey + '=' + parameterMap.get(eachKey));
+        }
+
+        // Join the name-value pairs into a string
+        return String.join(pairs, '&');
+    }
+}

--- a/src/classes/HttpUtil.cls
+++ b/src/classes/HttpUtil.cls
@@ -1,5 +1,14 @@
 global class HttpUtil {
 
+    global static final String CONTENT_TYPE_HEADER = 'ContentType';
+
+    global static final String GET_METHOD = 'GET';
+
+    global static final String POST_METHOD = 'POST';
+
+    global static final String X_WWW_FORM_URLENCODED_CONTENT_TYPE =
+            'application/x-www-form-urlencoded';
+
     /**
      * Given a map of name-value pairs, serialize the map into a string
      * that works as a URL query string. This method assumes that the values

--- a/src/classes/HttpUtil.cls-meta.xml
+++ b/src/classes/HttpUtil.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/PageService.cls
+++ b/src/classes/PageService.cls
@@ -1,0 +1,28 @@
+public with sharing class PageService {
+
+    private static Map<PageReference, PageService> instanceMap =
+            new Map<PageReference, PageService>();
+
+    private PageReference page;
+
+    public PageService(PageReference page) {
+        this.page = page;
+    }
+
+    public static PageService getInstance(PageReference page) {
+        if (!instanceMap.containsKey(page)) {
+            instanceMap.put(page, newInstance(page));
+        }
+
+        return instanceMap.get(page);
+    }
+
+    public String getParameter(String name) {
+        return this.page.getParameters().get(name);
+    }
+
+    public static PageService newInstance(PageReference page) {
+        PageService instance = new PageService(page);
+        return instance;
+    }
+}

--- a/src/classes/PageService.cls-meta.xml
+++ b/src/classes/PageService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlackApi.cls
+++ b/src/classes/SlackApi.cls
@@ -1,0 +1,47 @@
+public class SlackApi {
+    public class OauthAccessResponse extends Response {
+        public String access_token { get; set; }
+        public String scope { get; set; }
+        public String team_id { get; set; }
+        public String team_name { get; set; }
+        public String user_id { get; set; }
+    }
+
+    public class Icon {
+        public String image_34 { get; set; }
+        public String image_44 { get; set; }
+        public String image_68 { get; set; }
+        public String image_88 { get; set; }
+        public String image_102 { get; set; }
+        public String image_132 { get; set; }
+        public Boolean image_default { get; set; }
+    }
+
+    public virtual class Response {
+        public Boolean ok { get; set; }
+    }
+
+    public class Team {
+        public String domain { get; set; }
+        public String email_domain { get; set; }
+        public String enterprise_id { get; set; }
+        public String enterprise_name { get; set; }
+        public Icon icon { get; set; }
+        public String id { get; set; }
+        public String name { get; set; }
+    }
+
+    public class TeamInfoResponse extends Response {
+        public Team team { get; set; }
+    }
+
+    public class User {
+        public String id { get; set; }
+        public String team_id { get; set; }
+        public String tz { get; set; }
+    }
+
+    public class UsersInfoResponse extends Response {
+        public SlackApi.User user { get; set; }
+    }
+}

--- a/src/classes/SlackApi.cls-meta.xml
+++ b/src/classes/SlackApi.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlackApiService.cls
+++ b/src/classes/SlackApiService.cls
@@ -33,7 +33,7 @@ public with sharing class SlackApiService {
 
         // Initialize the request
         HttpRequest req = new HttpRequest();
-        req.setMethod('GET');
+        req.setMethod(HttpUtil.GET_METHOD);
 
         // Construct the endpoint
         Map<String, String> parameterMap = new Map<String, String> {
@@ -59,8 +59,9 @@ public with sharing class SlackApiService {
 
         // Initialize the request
         HttpRequest req = new HttpRequest();
-        req.setMethod('POST');
-        req.setHeader('ContentType', 'application/x-www-form-urlencoded');
+        req.setMethod(HttpUtil.POST_METHOD);
+        req.setHeader(HttpUtil.CONTENT_TYPE_HEADER,
+                HttpUtil.X_WWW_FORM_URLENCODED_CONTENT_TYPE);
         req.setEndpoint(this.getBaseUrl() + '/team.info');
 
         // Construct the request body
@@ -75,5 +76,29 @@ public with sharing class SlackApiService {
 
         return (SlackApi.TeamInfoResponse)JSON.deserialize(
                 res.getBody(), SlackApi.TeamInfoResponse.class);
+    }
+
+    public SlackApi.UsersInfoResponse usersInfo(String userId) {
+
+        // Initialize the request
+        HttpRequest req = new HttpRequest();
+        req.setMethod(HttpUtil.POST_METHOD);
+        req.setHeader(HttpUtil.CONTENT_TYPE_HEADER,
+                HttpUtil.X_WWW_FORM_URLENCODED_CONTENT_TYPE);
+        req.setEndpoint(this.getBaseUrl() + '/users.info');
+
+        // Construct the request body
+        Map<String, String> parameterMap = new Map<String, String> {
+            'token' => this.accessToken,
+            'user' => userId
+        };
+
+        req.setBody(HttpUtil.serializeQuery(parameterMap));
+
+        // Parse and return the response
+        HttpResponse res = new Http().send(req);
+
+        return (SlackApi.UsersInfoResponse)JSON.deserialize(
+                res.getBody(), SlackApi.UsersInfoResponse.class);
     }
 }

--- a/src/classes/SlackApiService.cls
+++ b/src/classes/SlackApiService.cls
@@ -44,7 +44,7 @@ public with sharing class SlackApiService {
 
         req.setEndpoint(String.join(new List<String> {
             this.getBaseUrl(),
-            '/oauth.access&',
+            '/oauth.access?',
             HttpUtil.serializeQuery(parameterMap)
         }, ''));
 
@@ -60,6 +60,7 @@ public with sharing class SlackApiService {
         // Initialize the request
         HttpRequest req = new HttpRequest();
         req.setMethod('POST');
+        req.setHeader('ContentType', 'application/x-www-form-urlencoded');
         req.setEndpoint(this.getBaseUrl() + '/team.info');
 
         // Construct the request body

--- a/src/classes/SlackApiService.cls
+++ b/src/classes/SlackApiService.cls
@@ -1,0 +1,78 @@
+public with sharing class SlackApiService {
+
+    private String accessToken;
+
+    public SlackApiService() {
+        this(null);
+    }
+
+    public SlackApiService(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getBaseUrl() {
+        return 'https://slack.com/api';
+    }
+
+    public static SlackApiService getInstance() {
+        return new SlackApiService();
+    }
+
+    public static SlackApiService getInstance(String accessToken) {
+        return new SlackApiService(accessToken);
+    }
+
+    public SlackApi.OauthAccessResponse oauthAccess(
+            Connection__c conn, String authCode) {
+        return this.oauthAccess(
+                conn.ClientId__c, conn.ClientSecret__c, authCode);
+    }
+
+    public SlackApi.OauthAccessResponse oauthAccess(
+            String clientId, String clientSecret, String authCode) {
+
+        // Initialize the request
+        HttpRequest req = new HttpRequest();
+        req.setMethod('GET');
+
+        // Construct the endpoint
+        Map<String, String> parameterMap = new Map<String, String> {
+            'client_id' => clientId,
+            'client_secret' => clientSecret,
+            'code' => authCode
+        };
+
+        req.setEndpoint(String.join(new List<String> {
+            this.getBaseUrl(),
+            '/oauth.access&',
+            HttpUtil.serializeQuery(parameterMap)
+        }, ''));
+
+        // Parse and return the response
+        HttpResponse res = new Http().send(req);
+
+        return (SlackApi.OauthAccessResponse)JSON.deserialize(
+                res.getBody(), SlackApi.OauthAccessResponse.class);
+    }
+
+    public SlackApi.TeamInfoResponse teamInfo() {
+
+        // Initialize the request
+        HttpRequest req = new HttpRequest();
+        req.setMethod('POST');
+        req.setEndpoint(this.getBaseUrl() + '/team.info');
+
+        // Construct the request body
+        Map<String, String> parameterMap = new Map<String, String> {
+            'token' => this.accessToken
+        };
+
+        req.setBody(HttpUtil.serializeQuery(parameterMap));
+
+        // Parse and return the response
+        HttpResponse res = new Http().send(req);
+
+        return (SlackApi.TeamInfoResponse)JSON.deserialize(
+                res.getBody(), SlackApi.TeamInfoResponse.class);
+    }
+}

--- a/src/classes/SlackApiService.cls-meta.xml
+++ b/src/classes/SlackApiService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlackApiUsersInfoAcmeBunnyMock.cls
+++ b/src/classes/SlackApiUsersInfoAcmeBunnyMock.cls
@@ -1,0 +1,31 @@
+public with sharing class SlackApiUsersInfoAcmeBunnyMock implements SmartMock {
+    public Boolean handles(HttpRequest req) {
+        
+        // Assume the request cannot be handled
+        Boolean canHandle = false;
+
+        // Examine the request, looking for the presence of the expected
+        // access token and and the user ID
+        if (req.getEndpoint().startsWith('https://slack.com/api/users.info')
+                && req.getBody() != null) {
+            Map<String, String> parameters =
+                    HttpUtil.deserializeQuery(req.getBody());
+
+            canHandle = parameters.get('user') == 'bunny';
+        }
+
+        // Return the verdict
+        return canHandle;
+    }
+
+    public HttpResponse respond(HttpRequest req) {
+
+        // Initialize the response
+        HttpResponse res = new HttpResponse();
+
+        res.setBody(SmartMockService.getInstance(
+                SlackApiUsersInfoAcmeBunnyMock.class).getResponseBody());
+
+        return res;
+    }
+}

--- a/src/classes/SlackApiUsersInfoAcmeBunnyMock.cls
+++ b/src/classes/SlackApiUsersInfoAcmeBunnyMock.cls
@@ -6,7 +6,7 @@ public with sharing class SlackApiUsersInfoAcmeBunnyMock implements SmartMock {
 
         // Examine the request, looking for the presence of the expected
         // access token and and the user ID
-        if (req.getEndpoint().startsWith('https://slack.com/api/users.info')
+        if (req.getEndpoint().equals('https://slack.com/api/users.info')
                 && req.getBody() != null) {
             Map<String, String> parameters =
                     HttpUtil.deserializeQuery(req.getBody());

--- a/src/classes/SlackApiUsersInfoAcmeBunnyMock.cls-meta.xml
+++ b/src/classes/SlackApiUsersInfoAcmeBunnyMock.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlackApiUsersInfoBarFooMock.cls
+++ b/src/classes/SlackApiUsersInfoBarFooMock.cls
@@ -1,0 +1,31 @@
+public with sharing class SlackApiUsersInfoBarFooMock implements SmartMock {
+    public Boolean handles(HttpRequest req) {
+        
+        // Assume the request cannot be handled
+        Boolean canHandle = false;
+
+        // Examine the request, looking for the presence of the expected
+        // access token and and the user ID
+        if (req.getEndpoint().equals('https://slack.com/api/users.info')
+                && req.getBody() != null) {
+            Map<String, String> parameters =
+                    HttpUtil.deserializeQuery(req.getBody());
+
+            canHandle = parameters.get('user') == 'foo';
+        }
+
+        // Return the verdict
+        return canHandle;
+    }
+
+    public HttpResponse respond(HttpRequest req) {
+
+        // Initialize the response
+        HttpResponse res = new HttpResponse();
+
+        res.setBody(SmartMockService.getInstance(
+                SlackApiUsersInfoBarFooMock.class).getResponseBody());
+
+        return res;
+    }
+}

--- a/src/classes/SlackApiUsersInfoBarFooMock.cls-meta.xml
+++ b/src/classes/SlackApiUsersInfoBarFooMock.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlackApiUsersInfoBoardFlipMock.cls
+++ b/src/classes/SlackApiUsersInfoBoardFlipMock.cls
@@ -1,0 +1,31 @@
+public with sharing class SlackApiUsersInfoBoardFlipMock implements SmartMock {
+    public Boolean handles(HttpRequest req) {
+        
+        // Assume the request cannot be handled
+        Boolean canHandle = false;
+
+        // Examine the request, looking for the presence of the expected
+        // access token and and the user ID
+        if (req.getEndpoint().equals('https://slack.com/api/users.info')
+                && req.getBody() != null) {
+            Map<String, String> parameters =
+                    HttpUtil.deserializeQuery(req.getBody());
+
+            canHandle = parameters.get('user') == 'flip';
+        }
+
+        // Return the verdict
+        return canHandle;
+    }
+
+    public HttpResponse respond(HttpRequest req) {
+
+        // Initialize the response
+        HttpResponse res = new HttpResponse();
+
+        res.setBody(SmartMockService.getInstance(
+                SlackApiUsersInfoBoardFlipMock.class).getResponseBody());
+
+        return res;
+    }
+}

--- a/src/classes/SlackApiUsersInfoBoardFlipMock.cls-meta.xml
+++ b/src/classes/SlackApiUsersInfoBoardFlipMock.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlackService.cls
+++ b/src/classes/SlackService.cls
@@ -36,7 +36,7 @@ public with sharing class SlackService {
 
         // Look for an existing account
         List<Account> teamAccounts = [
-            SELECT Id, Name
+            SELECT Id, Name, SlackAccessToken__c
             FROM Account
             WHERE SlackTeamId__c = :this.teamId
         ];
@@ -48,7 +48,7 @@ public with sharing class SlackService {
 
         // Look for a existing contact
         List<Contact> userContacts = [
-            SELECT Id, TimeZoneSidKey__c
+            SELECT Id, SlackUserId__c, TimeZoneSidKey__c
             FROM Contact
             WHERE AccountId = :findOrCreateAccount().Id
                 AND SlackUserId__c = :userId
@@ -63,6 +63,35 @@ public with sharing class SlackService {
         }
 
         return instanceMap.get(teamId);
+    }
+
+    /**
+     * Get the time zone for a given Slack user, preferably from Slack if
+     * possible but if not then whatever is on file for the user.
+     * If the time zone obtained from Slack is different than what's on file
+     * for the user, the information in Salesforce should be updated
+     * to match the user's Slack configuration.
+     *
+     * @return the time zone SID key (e.g., "America/New_York")
+     */
+    public String getTimeZoneSidKey(Contact userContact) {
+
+        // Get the time zone from Slack
+        SlackApiService teamSlackApi = SlackApiService.getInstance(
+                this.findOrCreateAccount().SlackAccessToken__c);
+
+        SlackApi.UsersInfoResponse usersInfo =
+                teamSlackApi.usersInfo(userContact.SlackUserId__c);
+
+        // Update the contact's time zone if the user's current time
+        // zone is different
+        if (usersInfo.user.tz != userContact.TimeZoneSidKey__c) {
+            userContact.TimeZoneSidKey__c = usersInfo.user.tz;
+            update userContact;
+        }
+
+        // Return the user's time zone
+        return userContact.TimeZoneSidKey__c;
     }
 
     public Account storeAccessToken(String accessToken) {

--- a/src/classes/SlackService.cls
+++ b/src/classes/SlackService.cls
@@ -87,7 +87,7 @@ public with sharing class SlackService {
         // zone is different
         if (usersInfo.user.tz != userContact.TimeZoneSidKey__c) {
             userContact.TimeZoneSidKey__c = usersInfo.user.tz;
-            update userContact;
+            DatabaseUtil.updateLater(userContact);
         }
 
         // Return the user's time zone

--- a/src/classes/SlackService.cls
+++ b/src/classes/SlackService.cls
@@ -64,4 +64,12 @@ public with sharing class SlackService {
 
         return instanceMap.get(teamId);
     }
+
+    public Account storeAccessToken(String accessToken) {
+
+        Account teamAccount = this.findOrCreateAccount();
+        teamAccount.SlackAccessToken__c = accessToken;
+        update teamAccount;
+        return teamAccount;
+    }
 }

--- a/src/classes/SlackService.cls
+++ b/src/classes/SlackService.cls
@@ -74,6 +74,27 @@ public with sharing class SlackService {
      *
      * @return the time zone SID key (e.g., "America/New_York")
      */
+    public String getTimeZoneSidKey(String userId) {
+
+        // Get the time zone from Slack
+        SlackApiService teamSlackApi = SlackApiService.getInstance(
+                this.findOrCreateAccount().SlackAccessToken__c);
+
+        SlackApi.UsersInfoResponse usersInfo = teamSlackApi.usersInfo(userId);
+
+        // Return the user's time zone
+        return usersInfo.user.tz;
+    }
+
+    /**
+     * Get the time zone for a given Slack user, preferably from Slack if
+     * possible but if not then whatever is on file for the user.
+     * If the time zone obtained from Slack is different than what's on file
+     * for the user, the information in Salesforce should be updated
+     * to match the user's Slack configuration.
+     *
+     * @return the time zone SID key (e.g., "America/New_York")
+     */
     public String getTimeZoneSidKey(Contact userContact) {
 
         // Get the time zone from Slack

--- a/src/classes/SlackUtil.cls
+++ b/src/classes/SlackUtil.cls
@@ -27,4 +27,8 @@ public with sharing class SlackUtil {
     public static String format(SlashclockReportItem item) {
         return item.format();
     }
+
+    public static String getWorkspaceUrl(String domain) {
+        return 'https://' + domain + '.slack.com';
+    }
 }

--- a/src/classes/SlashclockCallbackController.cls
+++ b/src/classes/SlashclockCallbackController.cls
@@ -1,5 +1,47 @@
 public with sharing class SlashclockCallbackController {
+
+    public static final String CODE_PARAMETER = 'code';
+
+    public static final String STATE_PARAMETER = 'state';
+
+    public String message { get; set; }
+
     public PageReference load() {
-        return null;
+
+        // Visualforce it up!
+        PageService force = PageService.getInstance(ApexPages.currentPage());
+
+        // Get the code and state
+        String code = force.getParameter(CODE_PARAMETER);
+        String state = force.getParameter(STATE_PARAMETER);
+
+
+        // Assume the worst and try for the best
+        PageReference nextPage = null;
+
+        try {
+
+            // Get the access token
+            SlackApiService slack = SlackApiService.getInstance();
+            SlackApi.OauthAccessResponse oauthAccess =
+                    slack.oauthAccess(Connection__c.getInstance('Slack'), code);
+            String accessToken = oauthAccess.access_token;
+
+            // Store the access token
+            SlackService slacker = SlackService.getInstance(oauthAccess.team_id);
+            slacker.storeAccessToken(accessToken);
+
+            // Determine the appropriate next page for the team
+            SlackApiService teamSlack = SlackApiService.getInstance(accessToken);
+            SlackApi.TeamInfoResponse teamInfo = teamSlack.teamInfo();
+            nextPage = new PageReference(
+                    SlackUtil.getWorkspaceUrl(teamInfo.team.domain));
+        }
+        catch (System.Exception caught) {
+            this.message = JSON.serialize(caught);
+        }
+
+        // Use Slack to get the 
+        return nextPage;
     }
 }

--- a/src/classes/SlashclockCallbackController.cls
+++ b/src/classes/SlashclockCallbackController.cls
@@ -27,13 +27,15 @@ public with sharing class SlashclockCallbackController {
                     slack.oauthAccess(Connection__c.getInstance('Slack'), code);
             String accessToken = oauthAccess.access_token;
 
+            // Determine the appropriate next page for the team
+            SlackApiService teamSlack = SlackApiService.getInstance(accessToken);
+            SlackApi.TeamInfoResponse teamInfo = teamSlack.teamInfo();
+
             // Store the access token
             SlackService slacker = SlackService.getInstance(oauthAccess.team_id);
             slacker.storeAccessToken(accessToken);
 
-            // Determine the appropriate next page for the team
-            SlackApiService teamSlack = SlackApiService.getInstance(accessToken);
-            SlackApi.TeamInfoResponse teamInfo = teamSlack.teamInfo();
+            // Prepare to redirect the user back to the Slack workspace
             nextPage = new PageReference(
                     SlackUtil.getWorkspaceUrl(teamInfo.team.domain));
         }

--- a/src/classes/SlashclockCallbackController.cls
+++ b/src/classes/SlashclockCallbackController.cls
@@ -1,0 +1,5 @@
+public with sharing class SlashclockCallbackController {
+    public PageReference load() {
+        return null;
+    }
+}

--- a/src/classes/SlashclockCallbackController.cls-meta.xml
+++ b/src/classes/SlashclockCallbackController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlashclockInCommand.cls
+++ b/src/classes/SlashclockInCommand.cls
@@ -51,11 +51,10 @@ public with sharing class SlashclockInCommand implements Slashclock.Command {
         // then locate the contact and the time zone
         this.userId = command.SlackUserId__c;
         this.teamId = command.SlackTeamId__c;
-
-        Contact userContact = SlackService.getInstance(
-                this.teamId).findOrCreateContact(this.userId);
-
-        this.timeZoneSidKey = userContact.TimeZoneSidKey__c;
+        
+        SlackService slacker = SlackService.getInstance(this.teamId);
+        Contact userContact = slacker.findOrCreateContact(this.userId);
+        this.timeZoneSidKey = slacker.getTimeZoneSidKey(userContact);
 
         // Store a matcher for the command
         Matcher matcher = getPattern().matcher(command.Text__c);

--- a/src/classes/SlashclockInCommand.cls
+++ b/src/classes/SlashclockInCommand.cls
@@ -53,8 +53,15 @@ public with sharing class SlashclockInCommand implements Slashclock.Command {
         this.teamId = command.SlackTeamId__c;
         
         SlackService slacker = SlackService.getInstance(this.teamId);
+        this.timeZoneSidKey = slacker.getTimeZoneSidKey(this.userId);
+
+        // Update the contact's time zone if it's determined to be
         Contact userContact = slacker.findOrCreateContact(this.userId);
-        this.timeZoneSidKey = slacker.getTimeZoneSidKey(userContact);
+
+        if (userContact.TimeZoneSidKey__c != this.timeZoneSidKey) {
+            userContact.TimeZoneSidKey__c = this.timeZoneSidKey;
+            DatabaseUtil.updateLater(userContact);
+        }
 
         // Store a matcher for the command
         Matcher matcher = getPattern().matcher(command.Text__c);

--- a/src/classes/SlashclockInCommandTest.cls
+++ b/src/classes/SlashclockInCommandTest.cls
@@ -71,6 +71,7 @@ private class SlashclockInCommandTest {
                 americaNewYork).getTime();
 
         // When
+        Test.setMock(HttpCalloutMock.class, new SlashclockMockSuite());
         Test.startTest();
 
         command.load(userCommand);

--- a/src/classes/SlashclockInCommandTest.cls
+++ b/src/classes/SlashclockInCommandTest.cls
@@ -24,6 +24,7 @@ private class SlashclockInCommandTest {
         Long defaultStartTime = command.getStartTime().getTime();
 
         // When
+        Test.setMock(HttpCalloutMock.class, new SlashclockMockSuite());
         Test.startTest();
 
         command.load(userCommand);

--- a/src/classes/SlashclockInCommandTest.cls
+++ b/src/classes/SlashclockInCommandTest.cls
@@ -85,4 +85,9 @@ private class SlashclockInCommandTest {
                 DateTime.newInstance(actualStartTime),
                 'SlashclockInCommand.startTime');
     }
+
+    @testSetup
+    private static void setup() {
+        TestService.getInstance().setup();
+    }
 }

--- a/src/classes/SlashclockMockSuite.cls
+++ b/src/classes/SlashclockMockSuite.cls
@@ -1,5 +1,13 @@
-public class SlashclockMockSuite implements HttpCalloutMock {
-    public HttpResponse respond(HttpRequest req) {
-        return null;
+public class SlashclockMockSuite extends AbstractSmartMockSuite {
+    public override List<SmartMock> getMocks() {
+        return new List<SmartMock> {
+            new SlackApiUsersInfoAcmeBunnyMock()
+        };
+    }
+
+    public Boolean handles(HttpRequest req) {
+
+        // Since this is an all-encompassing mock suite...
+        return true;
     }
 }

--- a/src/classes/SlashclockMockSuite.cls
+++ b/src/classes/SlashclockMockSuite.cls
@@ -1,0 +1,5 @@
+public class SlashclockMockSuite implements HttpCalloutMock {
+    public HttpResponse respond(HttpRequest req) {
+        return null;
+    }
+}

--- a/src/classes/SlashclockMockSuite.cls
+++ b/src/classes/SlashclockMockSuite.cls
@@ -1,7 +1,9 @@
 public class SlashclockMockSuite extends AbstractSmartMockSuite {
     public override List<SmartMock> getMocks() {
         return new List<SmartMock> {
-            new SlackApiUsersInfoAcmeBunnyMock()
+            new SlackApiUsersInfoAcmeBunnyMock(),
+            new SlackApiUsersInfoBarFooMock(),
+            new SlackApiUsersInfoBoardFlipMock()
         };
     }
 

--- a/src/classes/SlashclockMockSuite.cls-meta.xml
+++ b/src/classes/SlashclockMockSuite.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlashclockOutCommand.cls
+++ b/src/classes/SlashclockOutCommand.cls
@@ -49,8 +49,15 @@ public with sharing class SlashclockOutCommand implements Slashclock.Command {
         this.teamId = command.SlackTeamId__c;
         
         SlackService slacker = SlackService.getInstance(this.teamId);
+        this.timeZoneSidKey = slacker.getTimeZoneSidKey(this.userId);
+
+        // Update the contact's time zone if it's determined to be
         Contact userContact = slacker.findOrCreateContact(this.userId);
-        this.timeZoneSidKey = slacker.getTimeZoneSidKey(userContact);
+
+        if (userContact.TimeZoneSidKey__c != this.timeZoneSidKey) {
+            userContact.TimeZoneSidKey__c = this.timeZoneSidKey;
+            DatabaseUtil.updateLater(userContact);
+        }
 
         // Load the specific time if specified
         Matcher matcher = getPattern().matcher(command.Text__c);

--- a/src/classes/SlashclockOutCommand.cls
+++ b/src/classes/SlashclockOutCommand.cls
@@ -47,11 +47,10 @@ public with sharing class SlashclockOutCommand implements Slashclock.Command {
         // then locate the contact and the time zone
         this.userId = command.SlackUserId__c;
         this.teamId = command.SlackTeamId__c;
-
-        Contact userContact = SlackService.getInstance(
-                this.teamId).findOrCreateContact(this.userId);
-
-        this.timeZoneSidKey = userContact.TimeZoneSidKey__c;
+        
+        SlackService slacker = SlackService.getInstance(this.teamId);
+        Contact userContact = slacker.findOrCreateContact(this.userId);
+        this.timeZoneSidKey = slacker.getTimeZoneSidKey(userContact);
 
         // Load the specific time if specified
         Matcher matcher = getPattern().matcher(command.Text__c);

--- a/src/classes/SlashclockServiceTest.cls
+++ b/src/classes/SlashclockServiceTest.cls
@@ -11,7 +11,8 @@ private class SlashclockServiceTest {
     private static void clockInSuccess() {
 
         // Given
-        DateTime startTime = DateTime.now();
+        DateTime commandTime = DateTime.now();
+        DateTime startTime = DateTimeUtil.truncate(commandTime);
         String userId = 'foo';
         String teamId = 'bar';
 
@@ -29,7 +30,7 @@ private class SlashclockServiceTest {
         // When
         Test.startTest();
 
-        SlashclockService.getInstance(userId, teamId).clockIn(startTime);
+        SlashclockService.getInstance(userId, teamId).clockIn(commandTime);
 
         // Then
         Test.stopTest();

--- a/src/classes/SmartMock.cls
+++ b/src/classes/SmartMock.cls
@@ -1,0 +1,3 @@
+public interface SmartMock extends HttpCalloutMock {
+    Boolean handles(HttpRequest req);
+}

--- a/src/classes/SmartMock.cls-meta.xml
+++ b/src/classes/SmartMock.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SmartMockService.cls
+++ b/src/classes/SmartMockService.cls
@@ -1,0 +1,20 @@
+public with sharing class SmartMockService {
+
+    private Type mockType;
+
+	public SmartMockService(Type mockType) {
+		this.mockType = mockType;
+	}
+
+    public String getResponseBody() {
+        return [
+            SELECT Id, Name, Body
+            FROM StaticResource
+            WHERE Name = :this.mockType.getName()
+        ].Body.toString();
+    }
+
+    public static SmartMockService getInstance(Type mockType) {
+        return new SmartMockService(mockType);
+    }
+}

--- a/src/classes/SmartMockService.cls-meta.xml
+++ b/src/classes/SmartMockService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TestService.cls
+++ b/src/classes/TestService.cls
@@ -14,6 +14,14 @@ public with sharing class TestService {
         this.annotation = annotation;
     }
 
+    public String annotate(String value) {
+        return value + ' (' + this.getAnnotation() + ')';
+    }
+
+    public String getAnnotation() {
+        return this.annotation;
+    }
+
     public static TestService getInstance() {
         return new TestService(Test.isRunningTest());
     }
@@ -23,6 +31,21 @@ public with sharing class TestService {
      * and integration tests.
      */
     public void setup() {
+
+        // Create accounts
+        Account acme = new Account(
+                Name = this.annotate('Acme Corporation'),
+                SlackTeamId__c = 'acme');
+
+        Account cee = new Account(
+                Name = this.annotate('Cerebro, Inc.'),
+                SlackTeamId__c = 'cee');
+
+        Account board = new Account(
+                Name = this.annotate('Board, Inc.'),
+                SlackTeamId__c = 'board');
+
+        insert new List<Account> { acme, cee, board };
 
         // Create time entries
         TimeEntry__c emcee20170704 = new TimeEntry__c(

--- a/src/classes/TestService.cls
+++ b/src/classes/TestService.cls
@@ -45,7 +45,18 @@ public with sharing class TestService {
                 Name = this.annotate('Board, Inc.'),
                 SlackTeamId__c = 'board');
 
-        insert new List<Account> { acme, cee, board };
+        Account bar = new Account(
+                Name = this.annotate('Bar Service'),
+                SlackTeamId__c = 'bar');
+
+        insert new List<Account> { acme, cee, board, bar };
+
+        // Create contacts
+        Contact flip = new Contact(
+                AccountId = board.Id,
+                FirstName = 'Baxter',
+                LastName = this.annotate('Flip'),
+                SlackUserId__c = 'flip');
 
         // Create time entries
         TimeEntry__c emcee20170704 = new TimeEntry__c(

--- a/src/classes/UpdateJob.cls
+++ b/src/classes/UpdateJob.cls
@@ -1,0 +1,12 @@
+public with sharing class UpdateJob implements Queueable {
+
+    private List<Sobject> records;
+
+    public UpdateJob(List<Sobject> records) {
+        this.records = records;
+    }
+
+    public void execute(QueueableContext context) {
+        update this.records;
+    }
+}

--- a/src/classes/UpdateJob.cls-meta.xml
+++ b/src/classes/UpdateJob.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/objects/Account.object
+++ b/src/objects/Account.object
@@ -168,6 +168,16 @@
         <trackFeedHistory>false</trackFeedHistory>
     </fields>
     <fields>
+        <fullName>SlackAccessToken__c</fullName>
+        <externalId>false</externalId>
+        <label>Slack Access Token</label>
+        <length>80</length>
+        <required>false</required>
+        <trackFeedHistory>false</trackFeedHistory>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>SlackTeamId__c</fullName>
         <caseSensitive>false</caseSensitive>
         <externalId>true</externalId>

--- a/src/objects/Connection__c.object
+++ b/src/objects/Connection__c.object
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customSettingsType>List</customSettingsType>
+    <description>Connection settings for invoking external APIs</description>
+    <enableFeeds>false</enableFeeds>
+    <fields>
+        <fullName>ClientId__c</fullName>
+        <externalId>false</externalId>
+        <label>Client ID</label>
+        <length>40</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>ClientSecret__c</fullName>
+        <externalId>false</externalId>
+        <label>Client Secret</label>
+        <length>40</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <label>Connection</label>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/src/objects/TimeEntry__c.object
+++ b/src/objects/TimeEntry__c.object
@@ -180,7 +180,7 @@
     <sharingModel>ReadWrite</sharingModel>
     <validationRules>
         <fullName>DurationCoversSlices</fullName>
-        <active>true</active>
+        <active>false</active>
         <description>When a time entry is closed, make sure the duration covers all sliced time. It doesn&apos;t make sense for the total duration of time slices to exceed the time entry&apos;s duration.</description>
         <errorConditionFormula>AND(
   NOT( ISBLANK( EndTime__c ) ) ,

--- a/src/package.xml
+++ b/src/package.xml
@@ -49,6 +49,7 @@
     </types>
     <types>
         <members>Account</members>
+        <members>Connection__c</members>
         <members>Contact</members>
         <members>SlashCommand__c</members>
         <members>TimeEntry__c</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -5,7 +5,11 @@
         <members>ClockResourceTest</members>
         <members>DateTimeUtil</members>
         <members>DateTimeUtilTest</members>
+        <members>HttpUtil</members>
+        <members>PageService</members>
         <members>Slack</members>
+        <members>SlackApi</members>
+        <members>SlackApiService</members>
         <members>SlackService</members>
         <members>SlackUtil</members>
         <members>SlashCommandUtil</members>
@@ -32,15 +36,11 @@
         <members>TimeUtil</members>
         <members>TimeUtilTest</members>
         <members>Weekday</members>
-        <members>PageService</members>
-        <members>SlackApi</members>
-        <members>SlackApiService</members>
-        <members>HttpUtil</members>
         <name>ApexClass</name>
     </types>
     <types>
-        <members>SlashclockHome</members>
         <members>SlashclockCallback</members>
+        <members>SlashclockHome</members>
         <name>ApexPage</name>
     </types>
     <types>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
+        <members>AbstractSmartMockSuite</members>
         <members>ClockResource</members>
         <members>ClockResourceTest</members>
         <members>DateTimeUtil</members>
@@ -10,6 +11,7 @@
         <members>Slack</members>
         <members>SlackApi</members>
         <members>SlackApiService</members>
+        <members>SlackApiUsersInfoAcmeBunnyMock</members>
         <members>SlackService</members>
         <members>SlackUtil</members>
         <members>SlashCommandUtil</members>
@@ -18,6 +20,7 @@
         <members>SlashclockException</members>
         <members>SlashclockInCommand</members>
         <members>SlashclockInCommandTest</members>
+        <members>SlashclockMockSuite</members>
         <members>SlashclockOutCommand</members>
         <members>SlashclockReport</members>
         <members>SlashclockReportCommand</members>
@@ -30,6 +33,8 @@
         <members>SlashclockServiceTest</members>
         <members>SlashclockUtil</members>
         <members>SlashclockUtilTest</members>
+        <members>SmartMock</members>
+        <members>SmartMockService</members>
         <members>TestService</members>
         <members>Time2</members>
         <members>TimeTest</members>
@@ -63,6 +68,10 @@
     <types>
         <members>TimeZoneSidKey</members>
         <name>GlobalValueSet</name>
+    </types>
+    <types>
+        <members>SlackApiUsersInfoAcmeBunnyMock</members>
+        <name>StaticResource</name>
     </types>
     <version>40.0</version>
 </Package>

--- a/src/package.xml
+++ b/src/package.xml
@@ -4,6 +4,7 @@
         <members>AbstractSmartMockSuite</members>
         <members>ClockResource</members>
         <members>ClockResourceTest</members>
+        <members>DatabaseUtil</members>
         <members>DateTimeUtil</members>
         <members>DateTimeUtilTest</members>
         <members>HttpUtil</members>
@@ -40,6 +41,7 @@
         <members>TimeTest</members>
         <members>TimeUtil</members>
         <members>TimeUtilTest</members>
+        <members>UpdateJob</members>
         <members>Weekday</members>
         <name>ApexClass</name>
     </types>

--- a/src/package.xml
+++ b/src/package.xml
@@ -32,6 +32,10 @@
         <members>TimeUtil</members>
         <members>TimeUtilTest</members>
         <members>Weekday</members>
+        <members>PageService</members>
+        <members>SlackApi</members>
+        <members>SlackApiService</members>
+        <members>HttpUtil</members>
         <name>ApexClass</name>
     </types>
     <types>

--- a/src/package.xml
+++ b/src/package.xml
@@ -13,6 +13,8 @@
         <members>SlackApi</members>
         <members>SlackApiService</members>
         <members>SlackApiUsersInfoAcmeBunnyMock</members>
+        <members>SlackApiUsersInfoBarFooMock</members>
+        <members>SlackApiUsersInfoBoardFlipMock</members>
         <members>SlackService</members>
         <members>SlackUtil</members>
         <members>SlashCommandUtil</members>
@@ -73,6 +75,8 @@
     </types>
     <types>
         <members>SlackApiUsersInfoAcmeBunnyMock</members>
+        <members>SlackApiUsersInfoBarFooMock</members>
+        <members>SlackApiUsersInfoBoardFlipMock</members>
         <name>StaticResource</name>
     </types>
     <version>40.0</version>

--- a/src/package.xml
+++ b/src/package.xml
@@ -10,6 +10,7 @@
         <members>SlackUtil</members>
         <members>SlashCommandUtil</members>
         <members>Slashclock</members>
+        <members>SlashclockCallbackController</members>
         <members>SlashclockException</members>
         <members>SlashclockInCommand</members>
         <members>SlashclockInCommandTest</members>
@@ -32,6 +33,11 @@
         <members>TimeUtilTest</members>
         <members>Weekday</members>
         <name>ApexClass</name>
+    </types>
+    <types>
+        <members>SlashclockHome</members>
+        <members>SlashclockCallback</members>
+        <name>ApexPage</name>
     </types>
     <types>
         <members>TimeEntryTrigger</members>

--- a/src/pages/SlashclockCallback.page
+++ b/src/pages/SlashclockCallback.page
@@ -1,0 +1,3 @@
+<apex:page sidebar="false" showHeader="false" standardStylesheets="false"
+           controller="SlashclockCallbackController" action="{!load}"
+           contentType="text">TODO</apex:page>

--- a/src/pages/SlashclockCallback.page
+++ b/src/pages/SlashclockCallback.page
@@ -1,3 +1,3 @@
 <apex:page sidebar="false" showHeader="false" standardStylesheets="false"
            controller="SlashclockCallbackController" action="{!load}"
-           contentType="text">TODO</apex:page>
+           contentType="text">{!message}</apex:page>

--- a/src/pages/SlashclockCallback.page-meta.xml
+++ b/src/pages/SlashclockCallback.page-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <availableInTouch>false</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <label>SlashclockCallback</label>
+</ApexPage>

--- a/src/pages/SlashclockHome.page
+++ b/src/pages/SlashclockHome.page
@@ -1,0 +1,3 @@
+<apex:page showHeader="false" sidebar="false" standardStylesheets="false">
+    <a href="https://slack.com/oauth/authorize?&client_id=199050446341.208351026596&scope=commands"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>
+</apex:page>

--- a/src/pages/SlashclockHome.page-meta.xml
+++ b/src/pages/SlashclockHome.page-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <availableInTouch>false</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <label>SlashclockHome</label>
+</ApexPage>

--- a/src/staticresources/SlackApiUsersInfoAcmeBunnyMock.resource
+++ b/src/staticresources/SlackApiUsersInfoAcmeBunnyMock.resource
@@ -1,0 +1,39 @@
+{
+    "ok": true,
+    "user": {
+        "id": "bunny",
+        "team_id": "acme",
+        "name": "bunny",
+        "deleted": false,
+        "color": "9f69e7",
+        "real_name": "Bugs Bunny",
+        "tz": "America/New_York",
+        "tz_label": "Eastern Daylight Time",
+        "tz_offset": -14400,
+        "profile": {
+            "first_name": "Bugs",
+            "last_name": "Bunny",
+            "avatar_hash": "g06f1a2f73d2",
+            "real_name": "Bugs Bunny",
+            "display_name": "bunny",
+            "real_name_normalized": "Bugs Bunny",
+            "display_name_normalized": "bunny",
+            "image_24": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=24&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-24.png",
+            "image_32": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=32&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-32.png",
+            "image_48": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-48.png",
+            "image_72": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=72&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-72.png",
+            "image_192": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0015-192.png",
+            "image_512": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0015-512.png",
+            "team": "acme"
+        },
+        "is_admin": true,
+        "is_owner": true,
+        "is_primary_owner": true,
+        "is_restricted": false,
+        "is_ultra_restricted": false,
+        "is_bot": false,
+        "updated": 1508974543,
+        "is_app_user": false,
+        "has_2fa": false
+    }
+}

--- a/src/staticresources/SlackApiUsersInfoAcmeBunnyMock.resource-meta.xml
+++ b/src/staticresources/SlackApiUsersInfoAcmeBunnyMock.resource-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <cacheControl>Private</cacheControl>
+    <contentType>application/javascript</contentType>
+</StaticResource>

--- a/src/staticresources/SlackApiUsersInfoBarFooMock.resource
+++ b/src/staticresources/SlackApiUsersInfoBarFooMock.resource
@@ -1,0 +1,39 @@
+{
+    "ok": true,
+    "user": {
+        "id": "foo",
+        "team_id": "bar",
+        "name": "foo",
+        "deleted": false,
+        "color": "9f69e7",
+        "real_name": "Toh Foo",
+        "tz": "America/Los_Angeles",
+        "tz_label": "Pacific Daylight Time",
+        "tz_offset": -14400,
+        "profile": {
+            "first_name": "Toh",
+            "last_name": "Foo",
+            "avatar_hash": "g06f1a2f73d2",
+            "real_name": "Toh Foo",
+            "display_name": "foo",
+            "real_name_normalized": "Toh Foo",
+            "display_name_normalized": "foo",
+            "image_24": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=24&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-24.png",
+            "image_32": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=32&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-32.png",
+            "image_48": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-48.png",
+            "image_72": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=72&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-72.png",
+            "image_192": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0015-192.png",
+            "image_512": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0015-512.png",
+            "team": "bar"
+        },
+        "is_admin": true,
+        "is_owner": true,
+        "is_primary_owner": true,
+        "is_restricted": false,
+        "is_ultra_restricted": false,
+        "is_bot": false,
+        "updated": 1508974543,
+        "is_app_user": false,
+        "has_2fa": false
+    }
+}

--- a/src/staticresources/SlackApiUsersInfoBarFooMock.resource-meta.xml
+++ b/src/staticresources/SlackApiUsersInfoBarFooMock.resource-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <cacheControl>Private</cacheControl>
+    <contentType>application/javascript</contentType>
+</StaticResource>

--- a/src/staticresources/SlackApiUsersInfoBoardFlipMock.resource
+++ b/src/staticresources/SlackApiUsersInfoBoardFlipMock.resource
@@ -1,0 +1,39 @@
+{
+    "ok": true,
+    "user": {
+        "id": "bunny",
+        "team_id": "acme",
+        "name": "bunny",
+        "deleted": false,
+        "color": "9f69e7",
+        "real_name": "Bugs Bunny",
+        "tz": "America/New_York",
+        "tz_label": "Eastern Daylight Time",
+        "tz_offset": -14400,
+        "profile": {
+            "first_name": "Bugs",
+            "last_name": "Bunny",
+            "avatar_hash": "g06f1a2f73d2",
+            "real_name": "Bugs Bunny",
+            "display_name": "bunny",
+            "real_name_normalized": "Bugs Bunny",
+            "display_name_normalized": "bunny",
+            "image_24": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=24&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-24.png",
+            "image_32": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=32&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-32.png",
+            "image_48": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-48.png",
+            "image_72": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=72&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0015-72.png",
+            "image_192": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0015-192.png",
+            "image_512": "https://secure.gravatar.com/avatar/06f1a2f73d247aef45630d9cc8715400.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0015-512.png",
+            "team": "acme"
+        },
+        "is_admin": true,
+        "is_owner": true,
+        "is_primary_owner": true,
+        "is_restricted": false,
+        "is_ultra_restricted": false,
+        "is_bot": false,
+        "updated": 1508974543,
+        "is_app_user": false,
+        "has_2fa": false
+    }
+}

--- a/src/staticresources/SlackApiUsersInfoBoardFlipMock.resource-meta.xml
+++ b/src/staticresources/SlackApiUsersInfoBoardFlipMock.resource-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <cacheControl>Private</cacheControl>
+    <contentType>application/javascript</contentType>
+</StaticResource>


### PR DESCRIPTION
When a Slack user clocks in and out, the user's time zone is checked via an API call. If there is a discrepancy between the user's real time zone as configured in Slack vs. what's on file in Salesforce, the time zone for the associated contact in Salesforce is updated to match.

Note, there is no `/clock zone` command, as the better UX (namely _no_ UX) was implemented as the solution here.