### PR TITLE
/clock slice

### DIFF
--- a/src/classes/Slashclock.cls
+++ b/src/classes/Slashclock.cls
@@ -21,6 +21,10 @@ public with sharing class Slashclock {
             return this.message;
         }
 
+        public Boolean isSuccess() {
+            return this.success;
+        }
+
         public void setMessage(String value) {
             this.message = value;
         }

--- a/src/classes/SlashclockInCommand.cls
+++ b/src/classes/SlashclockInCommand.cls
@@ -82,6 +82,6 @@ public with sharing class SlashclockInCommand implements Slashclock.Command {
     public Boolean matches(SlashCommand__c command) {
         
         // Return whether we found a match
-        return getPattern().matcher(command.Text__c).matches();
+        return command.Text__c.startsWith('in');
     }
 }

--- a/src/classes/SlashclockOutCommand.cls
+++ b/src/classes/SlashclockOutCommand.cls
@@ -75,6 +75,6 @@ public with sharing class SlashclockOutCommand implements Slashclock.Command {
     }
 
     public Boolean matches(SlashCommand__c command) {
-        return getPattern().matcher(command.Text__c).matches();
+        return command.Text__c.startsWith('out');
     }
 }

--- a/src/classes/SlashclockService.cls
+++ b/src/classes/SlashclockService.cls
@@ -171,6 +171,10 @@ public with sharing class SlashclockService {
         return report;
     }
 
+    public void slice(Decimal numberOfMinutes, String tag) {
+        
+    }
+
     public class Key {
         public String teamId { get; set; }
         public String userId { get; set; }

--- a/src/classes/SlashclockService.cls
+++ b/src/classes/SlashclockService.cls
@@ -133,6 +133,17 @@ public with sharing class SlashclockService {
         return new SlashclockService(userId, teamId);
     }
 
+    public TimeEntry__c getLastTimeEntry() {
+        return [
+            SELECT Id
+            FROM TimeEntry__c
+            WHERE SlackUserId__c = :this.userId
+                AND SlackTeamId__c = :this.teamId
+            ORDER BY StartTime__c DESC
+            LIMIT 1
+        ];
+    }
+
     public DateTime getStartOfWeek(DateTime value) {
         return DateTimeUtil.startOfWeek(
                 value, this.timeZoneSidKey, this.firstDayOfWeek);
@@ -171,8 +182,14 @@ public with sharing class SlashclockService {
         return report;
     }
 
-    public void slice(Decimal numberOfMinutes, String tag) {
-        
+    public TimeSlice__c slice(Decimal numberOfMinutes, String tag) {
+        TimeSlice__c slice = new TimeSlice__c(
+                TimeEntry__c = this.getLastTimeEntry().Id,
+                NumberOfMinutes__c = numberOfMinutes,
+                Tag__c = tag);
+
+        insert slice;
+        return slice;
     }
 
     public class Key {

--- a/src/classes/SlashclockSliceCommand.cls
+++ b/src/classes/SlashclockSliceCommand.cls
@@ -1,0 +1,77 @@
+public with sharing class SlashclockSliceCommand implements Slashclock.Command {
+
+    private Decimal numberOfMinutes;
+    private String tag;
+    private String teamId;
+    private String userId;
+
+    public SlashclockSliceCommand() {
+        this.userId = null;
+        this.teamId = null;
+        this.numberOfMinutes = 0;
+        this.tag = null;
+    }
+
+    public Slashclock.CommandResult execute() {
+
+        // Initialize the result
+        Slashclock.CommandResult result = new Slashclock.CommandResult();
+
+        // Clock in via service
+        try {
+            SlashclockService slashclock =
+                    SlashclockService.getInstance(this.userId, this.teamId);
+            slashclock.slice(this.numberOfMinutes, this.tag);
+            result.setMessage(Label.SlashclockSliceSuccess);
+            result.setSuccess(true);
+        }
+        catch (SlashclockException caught) {
+            result.setMessage(caught.getMessage());
+        }
+
+        // Return the result
+        return result;
+    }
+
+    /**
+     * @return a regex that shows the general structure of the command
+     *         to be three parts: slice, a time expression, a tag.
+     */
+    public static String getCommandRegex() {
+        return 'slice\\s+(.+)\\s+([^\\s]+)';
+    }
+
+    public static Pattern getPattern() {
+        return Pattern.compile(getCommandRegex());
+    }
+
+    public Slashclock.Command load(SlashCommand__c command) {
+
+        // Remember the Slack User ID and Team ID,
+        // then locate the contact and the time zone
+        this.userId = command.SlackUserId__c;
+        this.teamId = command.SlackTeamId__c;
+
+        // Store a matcher for the command
+        Matcher matcher = getPattern().matcher(command.Text__c);
+
+        // Load the specific time if it exists
+        if (matcher.matches()) {
+            this.numberOfMinutes = Time2.parse(matcher.group(1)).minutes();
+            this.tag = matcher.group(2);
+        }
+        else {
+            throw new SlashclockException(
+                    'I could not understand the parameters');
+        }
+        
+        // Return the fully loaded SlashClock command!
+        return this;
+    }
+
+    public Boolean matches(SlashCommand__c command) {
+        
+        // Return whether we found a match
+        return command.Text__c.startsWith('slice');
+    }
+}

--- a/src/classes/SlashclockSliceCommand.cls
+++ b/src/classes/SlashclockSliceCommand.cls
@@ -28,6 +28,11 @@ public with sharing class SlashclockSliceCommand implements Slashclock.Command {
         catch (SlashclockException caught) {
             result.setMessage(caught.getMessage());
         }
+        catch (System.DmlException caught) {
+
+            // TODO: Replace with more user-friendly error
+            result.setMessage(caught.getMessage());
+        }
 
         // Return the result
         return result;

--- a/src/classes/SlashclockSliceCommand.cls-meta.xml
+++ b/src/classes/SlashclockSliceCommand.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlashclockSliceCommandTest.cls
+++ b/src/classes/SlashclockSliceCommandTest.cls
@@ -224,6 +224,75 @@ private class SlashclockSliceCommandTest {
      */
     @isTest
     private static void sliceClosedEntry31MinutesError() {
-        System.assert(false, 'TODO');
+        
+        // Given
+        TimeEntry__c givenEntry = [
+            SELECT Id, DurationMinutes__c, NumberOfSlicedMinutes__c,
+                (
+                    SELECT Id, NumberOfMinutes__c, Tag__c
+                    FROM TimeSlices__r
+                    ORDER BY CreatedDate ASC
+                )
+            FROM TimeEntry__c
+            WHERE SlackTeamId__c = 'acme'
+            AND SlackUserId__c = 'daffy'
+            ORDER BY StartTime__c DESC
+            LIMIT 1
+        ];
+
+        System.assertEquals(60, givenEntry.DurationMinutes__c,
+                Schema.SObjectType.TimeEntry__c.fields.DurationMinutes__c.label);
+
+        System.assertEquals(30, givenEntry.NumberOfSlicedMinutes__c,
+                Schema.SObjectType.TimeEntry__c.fields.NumberOfSlicedMinutes__c.label);
+
+        System.assertEquals(1, givenEntry.TimeSlices__r.size(),
+                'given entry should have one slice');
+
+        System.assertEquals(30, givenEntry.TimeSlices__r[0].NumberOfMinutes__c,
+                Schema.SObjectType.TimeSlice__c.fields.NumberOfMinutes__c.label);
+
+        System.assertEquals('alpha', givenEntry.TimeSlices__r[0].Tag__c,
+                Schema.SObjectType.TimeSlice__c.fields.Tag__c.label);
+
+        // When
+        Test.startTest();
+
+        SlashCommand__c inboundCommand = new SlashCommand__c(
+                Command__c = '/clock',
+                Text__c = 'slice 31 minutes test',
+                SlackTeamId__c = 'acme',
+                SlackUserId__c = 'daffy');
+
+        Slashclock.CommandResult result =
+                SlashclockUtil.newCommand(inboundCommand).execute();
+
+        // Then
+        Test.stopTest();
+
+        TimeEntry__c thenEntry = [
+            SELECT Id, DurationMinutes__c, NumberOfSlicedMinutes__c,
+                (
+                    SELECT Id, NumberOfMinutes__c, Tag__c
+                    FROM TimeSlices__r
+                )
+            FROM TimeEntry__c
+            WHERE Id = :givenEntry.Id
+        ];
+
+        System.assertEquals(60, thenEntry.DurationMinutes__c,
+                Schema.SObjectType.TimeEntry__c.fields.DurationMinutes__c.label);
+
+        System.assertEquals(30, thenEntry.NumberOfSlicedMinutes__c,
+                Schema.SObjectType.TimeEntry__c.fields.NumberOfSlicedMinutes__c.label);
+
+        System.assertEquals(1 ,thenEntry.TimeSlices__r.size(),
+                'then entry should still only have one slice');
+
+        System.assertEquals(givenEntry.TimeSlices__r[0].Id, thenEntry.TimeSlices__r[0].Id,
+                'then entry slice should be same as given entry slice');
+
+        System.assertEquals(false, result.isSuccess(),
+                'result should indicate NOT success');
     }
 }

--- a/src/classes/SlashclockSliceCommandTest.cls
+++ b/src/classes/SlashclockSliceCommandTest.cls
@@ -1,0 +1,106 @@
+@isTest
+private class SlashclockSliceCommandTest {
+
+    @testSetup
+    private static void setup() {
+
+        // Create accounts
+        Account acme = new Account(
+                Name = 'Acme Corporation (TEST)',
+                SlackTeamId__c = 'acme');
+
+        insert new List<Account> {
+            acme
+        };
+
+        // Create contacts
+        Contact bugs = new Contact(
+                AccountId = acme.Id,
+                FirstName = 'Bugs',
+                LastName = 'Bunny (TEST)',
+                Email = 'bugs@acme.com.test',
+                SlackUserId__c = 'bugs');
+
+        Contact daffy = new Contact(
+                AccountId = acme.Id,
+                FirstName = 'Daffy',
+                LastName = 'Duck (TEST)',
+                Email = 'daffy@acme.com.test',
+                SlackUserId__c = 'daffy');
+
+        insert new List<Contact> {
+            bugs,
+            daffy
+        };
+
+        // Create time entries
+        TimeEntry__c bugs20171106930 = new TimeEntry__c(
+                SlackUserId__c = 'bugs',
+                SlackTeamId__c = 'acme',
+                Contact__c = bugs.Id,
+                StartTime__c = DateTime.newInstanceGmt(2017, 11, 6, 9, 30, 0),
+                EndTime__c = DateTime.newInstanceGmt(2017, 11, 6, 10, 30, 0));
+
+        TimeEntry__c bugs20171107930 = new TimeEntry__c(
+                SlackUserId__c = 'bugs',
+                SlackTeamId__c = 'acme',
+                Contact__c = bugs.Id,
+                StartTime__c = DateTime.newInstanceGmt(2017, 11, 7, 9, 30, 0));
+
+        TimeEntry__c daffy20171106930 = new TimeEntry__c(
+                SlackUserId__c = 'daffy',
+                SlackTeamId__c = 'acme',
+                Contact__c = daffy.Id,
+                StartTime__c = DateTime.newInstanceGmt(2017, 11, 6, 9, 30, 0),
+                EndTime__c = DateTime.newInstanceGmt(2017, 11, 6, 10, 30, 0));
+
+        insert new List<TimeEntry__c> {
+            bugs20171106930,
+            bugs20171107930,
+            daffy20171106930
+        };
+
+        // Create time slices
+        TimeSlice__c daffy20171106930alpha30 = new TimeSlice__c(
+                TimeEntry__c = daffy20171106930.Id,
+                NumberOfMinutes__c = 30,
+                Tag__c = 'alpha');
+
+        insert new List<TimeSlice__c> {
+            daffy20171106930alpha30
+        };
+    }
+
+    /**
+     * Given two time entries, with the last one being open with no slices;
+     * When a new "slice" command is executed for 30 minutes tagged "test";
+     * Then a new time slice should be created under the open time entry
+     * showing 30 minutes tagged "test"
+     */
+    @isTest
+    private static void sliceOpenEntry30Minutes() {
+        System.assert(false, 'TODO');
+    }
+
+    /**
+     * Given one closed time entry for 1 hour having a 30-minute slice;
+     * When a new "slice" command is executed for 30 minutes tagged "test";
+     * Then a new time slice should be created under the open time entry
+     * showing 30 minutes tagged "test"
+     */
+    @isTest
+    private static void sliceClosedEntry30MinutesSuccess() {
+        System.assert(false, 'TODO');
+    }
+
+    /**
+     * Given one closed time entry for 1 hour having a 30-minute slice;
+     * When a new "slice" command is executed for 31 minutes tagged "test";
+     * Then an error should be raised indicating the total sliced duration
+     * cannot be longer than the time entry itself
+     */
+    @isTest
+    private static void sliceClosedEntry31MinutesError() {
+        System.assert(false, 'TODO');
+    }
+}

--- a/src/classes/SlashclockSliceCommandTest.cls
+++ b/src/classes/SlashclockSliceCommandTest.cls
@@ -76,6 +76,8 @@ private class SlashclockSliceCommandTest {
      * When a new "slice" command is executed for 30 minutes tagged "test";
      * Then a new time slice should be created under the open time entry
      * showing 30 minutes tagged "test"
+     *
+     * @see https://api.slack.com/slash-commands
      */
     @isTest
     private static void sliceOpenEntry30Minutes() {
@@ -101,7 +103,8 @@ private class SlashclockSliceCommandTest {
         Test.startTest();
 
         SlashCommand__c inboundCommand = new SlashCommand__c(
-                Command__c = 'slice 30 minutes test',
+                Command__c = '/clock',
+                Text__c = 'slice 30 minutes test',
                 SlackTeamId__c = 'acme',
                 SlackUserId__c = 'bugs');
 

--- a/src/classes/SlashclockSliceCommandTest.cls
+++ b/src/classes/SlashclockSliceCommandTest.cls
@@ -141,7 +141,79 @@ private class SlashclockSliceCommandTest {
      */
     @isTest
     private static void sliceClosedEntry30MinutesSuccess() {
-        System.assert(false, 'TODO');
+        
+        // Given
+        TimeEntry__c givenEntry = [
+            SELECT Id, DurationMinutes__c, NumberOfSlicedMinutes__c,
+                (
+                    SELECT Id, NumberOfMinutes__c, Tag__c
+                    FROM TimeSlices__r
+                    ORDER BY CreatedDate ASC
+                )
+            FROM TimeEntry__c
+            WHERE SlackTeamId__c = 'acme'
+            AND SlackUserId__c = 'daffy'
+            ORDER BY StartTime__c DESC
+            LIMIT 1
+        ];
+
+        System.assertEquals(60, givenEntry.DurationMinutes__c,
+                Schema.SObjectType.TimeEntry__c.fields.DurationMinutes__c.label);
+
+        System.assertEquals(30, givenEntry.NumberOfSlicedMinutes__c,
+                Schema.SObjectType.TimeEntry__c.fields.NumberOfSlicedMinutes__c.label);
+
+        System.assertEquals(1, givenEntry.TimeSlices__r.size(),
+                'given entry should have one slice');
+
+        System.assertEquals(30, givenEntry.TimeSlices__r[0].NumberOfMinutes__c,
+                Schema.SObjectType.TimeSlice__c.fields.NumberOfMinutes__c.label);
+
+        System.assertEquals('alpha', givenEntry.TimeSlices__r[0].Tag__c,
+                Schema.SObjectType.TimeSlice__c.fields.Tag__c.label);
+
+        // When
+        Test.startTest();
+
+        SlashCommand__c inboundCommand = new SlashCommand__c(
+                Command__c = '/clock',
+                Text__c = 'slice 30 minutes test',
+                SlackTeamId__c = 'acme',
+                SlackUserId__c = 'daffy');
+
+        SlashclockUtil.newCommand(inboundCommand).execute();
+
+        // Then
+        Test.stopTest();
+
+        TimeEntry__c thenEntry = [
+            SELECT Id, DurationMinutes__c, NumberOfSlicedMinutes__c,
+                (
+                    SELECT Id, NumberOfMinutes__c, Tag__c
+                    FROM TimeSlices__r
+                )
+            FROM TimeEntry__c
+            WHERE Id = :givenEntry.Id
+        ];
+
+        System.assertEquals(60, thenEntry.DurationMinutes__c,
+                Schema.SObjectType.TimeEntry__c.fields.DurationMinutes__c.label);
+
+        System.assertEquals(60, thenEntry.NumberOfSlicedMinutes__c,
+                Schema.SObjectType.TimeEntry__c.fields.NumberOfSlicedMinutes__c.label);
+
+        System.assertEquals(2 ,thenEntry.TimeSlices__r.size(),
+                'then entry should have two slices');
+
+        Boolean has30MinutesTestSlice = false;
+
+        for (TimeSlice__c eachSlice : thenEntry.TimeSlices__r) {
+            if (eachSlice.NumberOfMinutes__c == 30 && eachSlice.Tag__c == 'test') {
+                has30MinutesTestSlice = true;
+            }
+        }
+
+        System.assert(has30MinutesTestSlice, 'then entry should have 30-minute test slice');
     }
 
     /**

--- a/src/classes/SlashclockSliceCommandTest.cls
+++ b/src/classes/SlashclockSliceCommandTest.cls
@@ -79,7 +79,55 @@ private class SlashclockSliceCommandTest {
      */
     @isTest
     private static void sliceOpenEntry30Minutes() {
-        System.assert(false, 'TODO');
+        
+        // Given
+        TimeEntry__c givenEntry = [
+            SELECT Id,
+                (
+                    SELECT Id, NumberOfMinutes__c, Tag__c
+                    FROM TimeSlices__r
+                )
+            FROM TimeEntry__c
+            WHERE SlackUserId__c = 'bugs'
+            AND SlackTeamId__c = 'acme'
+            ORDER BY StartTime__c DESC
+            LIMIT 1
+        ];
+
+        System.assertEquals(0, givenEntry.TimeSlices__r.size(),
+                'given entry should have no slices');
+
+        // When
+        Test.startTest();
+
+        SlashCommand__c inboundCommand = new SlashCommand__c(
+                Command__c = 'slice 30 minutes test',
+                SlackTeamId__c = 'acme',
+                SlackUserId__c = 'bugs');
+
+        SlashclockUtil.newCommand(inboundCommand).execute();
+
+        // Then
+        Test.stopTest();
+
+        TimeEntry__c thenEntry = [
+            SELECT Id,
+                (
+                    SELECT Id, NumberOfMinutes__c, Tag__c
+                    FROM TimeSlices__r
+                )
+            FROM TimeEntry__c
+            WHERE Id = :givenEntry.Id
+        ];
+
+        System.assertEquals(1 ,thenEntry.TimeSlices__r.size(),
+                'then entry should have one slice');
+
+        System.assertEquals(30, thenEntry.TimeSlices__r[0].NumberOfMinutes__c,
+                Schema.SObjectType.TimeSlice__c.fields.NumberOfMinutes__c.label);
+
+        System.assertEquals('test', thenEntry.TimeSlices__r[0].Tag__c,
+                Schema.SObjectType.TimeSlice__c.fields.Tag__c.label);
     }
 
     /**

--- a/src/classes/SlashclockSliceCommandTest.cls-meta.xml
+++ b/src/classes/SlashclockSliceCommandTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlashclockUtil.cls
+++ b/src/classes/SlashclockUtil.cls
@@ -3,7 +3,8 @@ public with sharing class SlashclockUtil {
         return new List<Slashclock.Command> {
             new SlashclockInCommand(),
             new SlashclockOutCommand(),
-            new SlashclockReportCommand()
+            new SlashclockReportCommand(),
+            new SlashclockSliceCommand()
         };
     }
 

--- a/src/classes/Time2.cls
+++ b/src/classes/Time2.cls
@@ -43,7 +43,7 @@ public class Time2 {
         Decimal total = this.days * 24 + this.remainder.hour();
         total += this.remainder.minute() / 60.0;
         total += this.remainder.second() / 60.0 / 60.0;
-        total += this.remainder.millisecond() / 60.0 / 60.0 / 60.0;
+        total += this.remainder.millisecond() / 1000.0 / 60.0 / 60.0;
         return total;
     }
 

--- a/src/classes/Time2.cls
+++ b/src/classes/Time2.cls
@@ -47,6 +47,14 @@ public class Time2 {
         return total;
     }
 
+    public Decimal minutes() {
+        Decimal hours = this.days * 24 + this.remainder.hour();
+        Decimal minutes = hours * 60 + this.remainder.minute();
+        return minutes
+                + this.remainder.second() / 60.0
+                + this.remainder.millisecond() / 1000.0 / 60.0;
+    }
+
     public static Time2 newInstance() {
         return newInstance(0, 0, 0, 0, 0);
     }

--- a/src/classes/Time2.cls
+++ b/src/classes/Time2.cls
@@ -27,6 +27,11 @@ public class Time2 {
         return this.hours() + 'h';
     }
 
+    public static Matcher getMatcher(String value) {
+        String regex = '([0-9.]+\\s+hours?)?\\s*([0-9.]+\\s+minutes?)?\\s*([0-9.]+\\s+seconds?)?';
+        return Pattern.compile(regex).matcher(value);
+    }
+
     public Long getTime() {
         return (((this.days * 24 /* hours per day */ + this.remainder.hour())
                 * 60 /* minutes per hour */ + this.remainder.minute())
@@ -52,6 +57,10 @@ public class Time2 {
         return new Time2(days, hours, minutes, seconds, millis);
     }
 
+    public static Time2 newInstance(Decimal totalMillis) {
+        return newInstance(totalMillis.longValue());
+    }
+
     public static Time2 newInstance(Long totalMillis) {
 
         // Truncate up to find useful values up each order of magnitude
@@ -71,5 +80,54 @@ public class Time2 {
         // Return the Time2 object
         return new Time2(
                 days, Time.newInstance(hours, minutes, seconds, millis));
+    }
+
+    /**
+     * Parse an increment of time, such as the following.
+     *
+     * - 10 seconds
+     * - 17 minutes
+     * - 1 hour
+     * - 2.5 hours
+     *
+     * @param value
+     *
+     * @return the time increment as a `Time2` object
+     *
+     * @see https://get.slack.help/hc/en-us/articles/208423427-set-a-reminder
+     */
+    public static Time2 parse(String value) {
+
+        // Initialize duration values
+        Decimal hours = 0;
+        Decimal minutes = 0;
+        Decimal seconds = 0;
+
+        // Define the regex used to parse the time.
+        // Assume times would be given in order of magnitude, starting
+        // with the largest unit.
+        Matcher matcher = getMatcher(value);
+
+        if (matcher.matches()) {
+
+            // Read the number of hours
+            if (!String.isEmpty(matcher.group(1))) {
+                hours = Decimal.valueOf(matcher.group(1).split('\\s')[0]);
+            }
+
+            // Read the number of minutes
+            if (!String.isEmpty(matcher.group(2))) {
+                minutes = Decimal.valueOf(matcher.group(2).split('\\s')[0]);
+            }
+
+            // Read the number of seconds
+            if (!String.isEmpty(matcher.group(3))) {
+                seconds = Decimal.valueOf(matcher.group(3).split('\\s')[0]);
+            }
+        }
+
+        // Return the parsed time
+        return Time2.newInstance(
+                ((hours * 60 + minutes) * 60 + seconds) * 1000);
     }
 }

--- a/src/classes/Time2Test.cls
+++ b/src/classes/Time2Test.cls
@@ -1,0 +1,84 @@
+@isTest
+private class Time2Test {
+
+    @isTest
+    private static void getMatcher() {
+
+        // Define expected outcomes
+        Map<String, List<String>> expectedValueMap = new Map<String, List<String>> {
+            '1 second' => new List<String> { null, null, '1 second' },
+            '10 seconds' => new List<String> { null, null, '10 seconds' },
+            '1 minute' => new List<String> { null, '1 minute', null },
+            '17 minutes' => new List<String> { null, '17 minutes', null },
+            '20 minutes 30 seconds' => new List<String> { null, '20 minutes', '30 seconds' },
+            '1 hour' => new List<String> { '1 hour', null, null },
+            '2.5 hours' => new List<String> { '2.5 hours', null, null },
+            '3 hours 30 minutes' => new List<String> { '3 hours', '30 minutes', null },
+            '3 hours 5 seconds' => new List<String> { '3 hours', null, '5 seconds' },
+            '3 hours 15 minutes 30 seconds' => new List<String> { '3 hours', '15 minutes', '30 seconds' }
+        };
+
+        // When
+        Test.startTest();
+
+        Map<String, Matcher> actualValueMap = new Map<String, Matcher>();
+
+        for (String eachValue : expectedValueMap.keySet()) {
+            actualValueMap.put(eachValue, Time2.getMatcher(eachValue));
+        }
+
+        // Then
+        Test.stopTest();
+
+        for (String eachValue : expectedValueMap.keySet()) {
+            List<String> expected = expectedValueMap.get(eachValue);
+            Matcher actual = actualValueMap.get(eachValue);
+
+            System.assert(actual.matches(), 'matcher: ' + eachValue);
+
+            for (Integer i = 0; i < expected.size(); i++) {
+                System.assertEquals(
+                        expected.get(i),
+                        actual.group(i + 1),
+                        eachValue);
+            }
+        }
+    }
+
+    @isTest
+    private static void parse() {
+
+        // Define expected outcomes
+        Map<String, Time2> expectedValueMap = new Map<String, Time2> {
+            '1 second' => Time2.newInstance(0, 0, 0, 1, 0),
+            '10 seconds' => Time2.newInstance(0, 0, 0, 10, 0),
+            '1 minute' => Time2.newInstance(0, 0, 1, 0, 0),
+            '17 minutes' => Time2.newInstance(0, 0, 17, 0, 0),
+            '20 minutes 30 seconds' => Time2.newInstance(0, 0, 20, 30, 0),
+            '1 hour' => Time2.newInstance(0, 1, 0, 0, 0),
+            '2.5 hours' => Time2.newInstance(0, 2, 30, 0, 0),
+            '3 hours 30 minutes' => Time2.newInstance(0, 3, 30, 0, 0),
+            '3 hours 5 seconds' => Time2.newInstance(0, 3, 0, 5, 0),
+            '3 hours 15 minutes 30 seconds' => Time2.newInstance(0, 3, 15, 30, 0)
+        };
+
+        // When
+        Test.startTest();
+
+        Map<String, Time2> actualValueMap = new Map<String, Time2>();
+
+        for (String eachValue : expectedValueMap.keySet()) {
+            actualValueMap.put(eachValue, Time2.parse(eachValue));
+        }
+
+        // Then
+        Test.stopTest();
+
+        for (String eachValue : expectedValueMap.keySet()) {
+            System.assertEquals(
+                    expectedValueMap.get(eachValue).getTime(),
+                    actualValueMap.get(eachValue).getTime(),
+                    eachValue);
+        }
+    }
+}

--- a/src/classes/Time2Test.cls-meta.xml
+++ b/src/classes/Time2Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+    <labels>
+        <fullName>SlashclockSliceSuccess</fullName>
+        <categories>slashclock</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>SlashclockSliceSuccess</shortDescription>
+        <value>Time sliced!</value>
+    </labels>
+</CustomLabels>

--- a/src/objects/TimeEntry__c.object
+++ b/src/objects/TimeEntry__c.object
@@ -180,7 +180,7 @@
     <sharingModel>ReadWrite</sharingModel>
     <validationRules>
         <fullName>DurationCoversSlices</fullName>
-        <active>false</active>
+        <active>true</active>
         <description>When a time entry is closed, make sure the duration covers all sliced time. It doesn&apos;t make sense for the total duration of time slices to exceed the time entry&apos;s duration.</description>
         <errorConditionFormula>AND(
   NOT( ISBLANK( EndTime__c ) ) ,

--- a/src/package.xml
+++ b/src/package.xml
@@ -34,6 +34,7 @@
         <members>SlashclockReportTest</members>
         <members>SlashclockService</members>
         <members>SlashclockServiceTest</members>
+        <members>SlashclockSliceCommand</members>
         <members>SlashclockUtil</members>
         <members>SlashclockUtilTest</members>
         <members>SmartMock</members>
@@ -56,6 +57,10 @@
     <types>
         <members>TimeEntryTrigger</members>
         <name>ApexTrigger</name>
+    </types>
+    <types>
+        <members>*</members>
+        <name>CustomLabels</name>
     </types>
     <types>
         <members>Account</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -45,6 +45,7 @@
         <members>TimeUtilTest</members>
         <members>UpdateJob</members>
         <members>Weekday</members>
+        <members>Time2Test</members>
         <name>ApexClass</name>
     </types>
     <types>

--- a/src/package.xml
+++ b/src/package.xml
@@ -35,6 +35,7 @@
         <members>SlashclockService</members>
         <members>SlashclockServiceTest</members>
         <members>SlashclockSliceCommand</members>
+        <members>SlashclockSliceCommandTest</members>
         <members>SlashclockUtil</members>
         <members>SlashclockUtilTest</members>
         <members>SmartMock</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -41,12 +41,12 @@
         <members>SmartMockService</members>
         <members>TestService</members>
         <members>Time2</members>
+        <members>Time2Test</members>
         <members>TimeTest</members>
         <members>TimeUtil</members>
         <members>TimeUtilTest</members>
         <members>UpdateJob</members>
         <members>Weekday</members>
-        <members>Time2Test</members>
         <name>ApexClass</name>
     </types>
     <types>


### PR DESCRIPTION
This pr adds support for a `/clock slice` command, which can be used to tag an amount of time (ultimately measured in minutes) on a time entry for reporting purposes. Sample commands below.

```txt
/clock slice 30 minutes qa
/clock slice 45 minutes build
/clock slice 2.5 hours training
```

A few other notable changes below.

* Reverted the `matches` implementation for earlier commands to the simple means of checking the starting characters in the command text
* Introduced a custom label for purposes of storing message templates