### PR TITLE
List entries and strike 'em

### DIFF
--- a/src/classes/SlashclockEntriesCommand.cls
+++ b/src/classes/SlashclockEntriesCommand.cls
@@ -1,0 +1,71 @@
+/**
+ * `/clock entries` returns a list of all time entries within the last seven
+ * days (i.e., 24 hours/day * 7 days), based on the Start Time. The entries
+ * should be returned in reverse chronologic order with the most recent entry
+ * at the top, and each entry should be displayed with a numeric index for
+ * use with the `/clock strike` command to delete a time entry.
+ */
+public with sharing class SlashclockEntriesCommand implements Slashclock.Command {
+
+    private DateTime currentTime;
+
+    /**
+     * The number of days to include when looking for entries to display
+     */
+    private Integer numberOfDays;
+
+    private String teamId;
+    private String userId;
+
+    public SlashclockEntriesCommand() {
+        this.userId = null;
+        this.teamId = null;
+        this.numberOfDays = 7;
+        this.currentTime = DateTime.now();
+    }
+
+    public Slashclock.CommandResult execute() {
+
+        // Initialize the result
+        Slashclock.CommandResult result = new Slashclock.CommandResult();
+
+        // Clock in via service
+        try {
+            SlashclockService slashclock =
+                    SlashclockService.getInstance(this.userId, this.teamId);
+
+            List<TimeEntry__c> entries = slashclock.getTimeEntriesSince(
+                    this.currentTime.addDays(-1 * numberOfDays));
+
+            result.setMessage(slashclock.formatEntries(entries));
+            result.setSuccess(true);
+        }
+        catch (SlashclockException caught) {
+            result.setMessage(caught.getMessage());
+        }
+
+        // Return the result
+        return result;
+    }
+
+    public Slashclock.Command load(SlashCommand__c command) {
+
+        // Remember the Slack User ID and Team ID,
+        // then locate the contact and the time zone
+        this.userId = command.SlackUserId__c;
+        this.teamId = command.SlackTeamId__c;
+        
+        // Figure out the time zone
+        SlackService slacker = SlackService.getInstance(this.teamId);
+        Contact userContact = slacker.findOrCreateContact(this.userId);
+        
+        // Return the fully loaded SlashClock command!
+        return this;
+    }
+
+    public Boolean matches(SlashCommand__c command) {
+        
+        // Return whether we found a match
+        return command.Text__c.startsWith('entries');
+    }
+}

--- a/src/classes/SlashclockEntriesCommand.cls-meta.xml
+++ b/src/classes/SlashclockEntriesCommand.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlashclockEntriesCommandTest.cls
+++ b/src/classes/SlashclockEntriesCommandTest.cls
@@ -1,0 +1,3 @@
+@isTest
+private class SlashclockEntriesCommandTest {
+}

--- a/src/classes/SlashclockEntriesCommandTest.cls-meta.xml
+++ b/src/classes/SlashclockEntriesCommandTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlashclockService.cls
+++ b/src/classes/SlashclockService.cls
@@ -83,6 +83,57 @@ public with sharing class SlashclockService {
         return entry;
     }
 
+    /**
+     * Given a list of time entries, format the time entries for display as
+     * a successful response to a `/clock entries` command
+     *
+     * @param entries
+     *
+     * @return a string that can be displayed prettily in Slack
+     */
+    public String formatEntries(List<TimeEntry__c> entries) {
+
+        // Initialize the lines in the response
+        List<String> lines = new List<String>();
+
+        // If no entries are given, the command should return a notification
+        // that there are no entries to display.
+        if (entries.isEmpty()) {
+            lines.add(Label.SlashclockEntriesNoEntries);
+        }
+        else {
+            lines.add(Label.SlashclockEntriesOpening);
+
+            for (TimeEntry__c eachEntry : entries) {
+                lines.add(this.formatEntry(eachEntry, lines.size()));
+            }
+        }
+
+        // Return the lines 
+        return String.join(lines, '\n');
+    }
+
+    /**
+     * Given a time entry and its index position within a list of time entries,
+     * format a string to return that can be displayed in a list appropriate
+     * for use with the `/clock entries` command.
+     *
+     * The line can be broken down into four parts.
+     *
+     * - The index number
+     * - The start date (in the user's local time zone)
+     * - The start time (in the user's local time zone)
+     * - The end date (in the user's local time zone) which may not be shown
+     * - The end time (in the user's local time zone)
+     *
+     * @param entry
+     *
+     * @return a formatted string showing the entry's info and its index
+     */
+    public String formatEntry(TimeEntry__c entry, Integer index) {
+        return SlashclockUtil.formatEntry(entry, index, this.timeZoneSidKey);
+    }
+
     public Time2 getClockedDuration(DateTime startTime, DateTime endTime) {
         Time2 duration = Time2.newInstance();
 
@@ -122,6 +173,17 @@ public with sharing class SlashclockService {
             WHERE SlackUserId__c = :this.userId
                 AND SlackTeamId__c = :this.teamId
                 AND EndTime__c = NULL
+        ];
+    }
+
+    public List<TimeEntry__c> getTimeEntriesSince(DateTime startTime) {
+        return [
+            SELECT Id, StartTime__c, EndTime__c
+            FROM TimeEntry__c
+            WHERE SlackUserId__c = :this.userId
+                AND SlackTeamId__c = :this.teamId
+                AND StartTime__c >= :startTime
+            ORDER BY StartTime__c DESC
         ];
     }
 

--- a/src/classes/SlashclockStrikeCommand.cls
+++ b/src/classes/SlashclockStrikeCommand.cls
@@ -1,0 +1,81 @@
+public with sharing class SlashclockStrikeCommand implements Slashclock.Command {
+
+    private DateTime currentTime;
+    
+    /**
+     * The index, starting at 1 (not 0), pointing to the time entry as shown
+     * in `/clock entries`, identifying the entry to strike or delete.
+     */
+    private Integer entryIndex;
+
+    private String teamId;
+    private String userId;
+
+    public SlashclockStrikeCommand() {
+        this.userId = null;
+        this.teamId = null;
+
+        this.currentTime = DateTime.now();
+        this.entryIndex = 1;  // by default strike the last time entry
+    }
+
+    public Slashclock.CommandResult execute() {
+
+        // Initialize the result
+        Slashclock.CommandResult result = new Slashclock.CommandResult();
+
+        // Clock in via service
+        try {
+            SlashclockService slashclock =
+                    SlashclockService.getInstance(this.userId, this.teamId);
+
+            TimeEntry__c struck = slashclock.getTimeEntriesSince(
+                    this.currentTime.addDays(-1 * 7)).get(this.entryIndex - 1);
+
+            delete struck;
+
+            result.setSuccess(true);
+            result.setMessage(Label.SlashclockStrikeSuccess.replace(
+                    '{0}', slashclock.formatEntry(struck, this.entryIndex)));
+        }
+        catch (SlashclockException caught) {
+            result.setMessage(caught.getMessage());
+        }
+
+        // Return the result
+        return result;
+    }
+
+    public static String getCommandRegex() {
+        return 'strike(\\s+(\\d+))?';
+    }
+
+    public static Pattern getPattern() {
+        return Pattern.compile(getCommandRegex());
+    }
+
+    public Slashclock.Command load(SlashCommand__c command) {
+
+        // Remember the Slack User ID and Team ID,
+        // then locate the contact and the time zone
+        this.userId = command.SlackUserId__c;
+        this.teamId = command.SlackTeamId__c;
+        
+        // Store a matcher for the command
+        Matcher matcher = getPattern().matcher(command.Text__c);
+
+        // Load the specific time if it exists
+        if (matcher.matches() && !String.isEmpty(matcher.group(2))) {
+            this.entryIndex = Integer.valueOf(matcher.group(2));
+        }
+        
+        // Return the fully loaded SlashClock command!
+        return this;
+    }
+
+    public Boolean matches(SlashCommand__c command) {
+        
+        // Return whether we found a match
+        return command.Text__c.startsWith('strike');
+    }
+}

--- a/src/classes/SlashclockStrikeCommand.cls-meta.xml
+++ b/src/classes/SlashclockStrikeCommand.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlashclockStrikeCommandTest.cls
+++ b/src/classes/SlashclockStrikeCommandTest.cls
@@ -1,3 +1,54 @@
 @isTest
 private class SlashclockStrikeCommandTest {
+
+    @testSetup
+    private static void setup() {
+        TestService.getInstance().setup();
+    }
+
+    /**
+     * Delete the most recent time entry
+     */
+    @isTest
+    private static void strikeFirstEntry() {
+
+        // Given
+        SlashCommand__c command = new SlashCommand__c(
+                SlackUserId__c = 'flip',
+                SlackTeamId__c = 'board',
+                Command__c = '/clock',
+                Text__c = 'strike 1');
+
+        List<TimeEntry__c> givenEntries = [
+            SELECT Id, StartTime__c, EndTime__c
+            FROM TimeEntry__c
+            WHERE SlackUserId__c = :command.SlackUserId__c
+                AND SlackTeamId__c = :command.SlackTeamId__c
+                AND StartTime__c >= :DateTime.now().addDays(-7)
+        ];
+
+        System.assertEquals(1, givenEntries.size());
+
+        // When
+        Test.startTest();
+
+        Slashclock.CommandResult result =
+                new SlashclockStrikeCommand().load(command).execute();
+
+        // Then
+        Test.stopTest();
+
+        List<TimeEntry__c> thenEntries = [
+            SELECT Id, StartTime__c, EndTime__c
+            FROM TimeEntry__c
+            WHERE SlackUserId__c = :command.SlackUserId__c
+                AND SlackTeamId__c = :command.SlackTeamId__c
+                AND StartTime__c >= :DateTime.now().addDays(-7)
+        ];
+
+        System.assertEquals(0, thenEntries.size());
+
+        System.assert(result.getMessage().startsWith('Entry deleted.\n1.'),
+                'message does not start as expected: ' + result.getMessage());
+    }
 }

--- a/src/classes/SlashclockStrikeCommandTest.cls
+++ b/src/classes/SlashclockStrikeCommandTest.cls
@@ -1,0 +1,3 @@
+@isTest
+private class SlashclockStrikeCommandTest {
+}

--- a/src/classes/SlashclockStrikeCommandTest.cls-meta.xml
+++ b/src/classes/SlashclockStrikeCommandTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/SlashclockUtil.cls
+++ b/src/classes/SlashclockUtil.cls
@@ -1,10 +1,18 @@
 public with sharing class SlashclockUtil {
+
+    public static String formatEntry(
+            TimeEntry__c entry, Integer index, String timeZoneSidKey) {
+        System.assert(false, 'TODO');
+        return null;
+    }
+
     public static List<Slashclock.Command> getKnownCommands() {
         return new List<Slashclock.Command> {
             new SlashclockInCommand(),
             new SlashclockOutCommand(),
             new SlashclockReportCommand(),
-            new SlashclockSliceCommand()
+            new SlashclockSliceCommand(),
+            new SlashclockEntriesCommand()
         };
     }
 

--- a/src/classes/SlashclockUtil.cls
+++ b/src/classes/SlashclockUtil.cls
@@ -18,7 +18,8 @@ public with sharing class SlashclockUtil {
             new SlashclockOutCommand(),
             new SlashclockReportCommand(),
             new SlashclockSliceCommand(),
-            new SlashclockEntriesCommand()
+            new SlashclockEntriesCommand(),
+            new SlashclockStrikeCommand()
         };
     }
 

--- a/src/classes/SlashclockUtil.cls
+++ b/src/classes/SlashclockUtil.cls
@@ -2,7 +2,6 @@ public with sharing class SlashclockUtil {
 
     public static String formatEntry(
             TimeEntry__c entry, Integer index, String timeZoneSidKey) {
-        System.assert(false, 'TODO');
         return null;
     }
 

--- a/src/classes/SlashclockUtil.cls
+++ b/src/classes/SlashclockUtil.cls
@@ -2,7 +2,14 @@ public with sharing class SlashclockUtil {
 
     public static String formatEntry(
             TimeEntry__c entry, Integer index, String timeZoneSidKey) {
-        return null;
+        return String.join(new List<String> {
+            index + '.',
+            entry.StartTime__c.format('EEE M/d h:mma', timeZoneSidKey),
+            '-',
+            entry.EndTime__c == null
+                    ? 'now'
+                    : entry.EndTime__c.format('h:mma', timeZoneSidKey)
+        }, ' ').replace('AM', 'am').replace('PM', 'pm');
     }
 
     public static List<Slashclock.Command> getKnownCommands() {

--- a/src/classes/SlashclockUtilTest.cls
+++ b/src/classes/SlashclockUtilTest.cls
@@ -40,13 +40,13 @@ private class SlashclockUtilTest {
         // Then
         Test.stopTest();
 
-        System.assertEquals('2. Mon 11/20 10:00pm to now', openEntryNewYorkTime);
+        System.assertEquals('2. Mon 11/20 10:00pm - now', openEntryNewYorkTime);
 
-        System.assertEquals('2. Tue 11/21 8:30am to now', openEntryKolkataTime);
+        System.assertEquals('2. Tue 11/21 8:30am - now', openEntryKolkataTime);
 
-        System.assertEquals('2. Sun 11/20 10:00pm to 6:30am', closedEntryNewYorkTime);
+        System.assertEquals('2. Sun 11/19 10:00pm - 6:30am', closedEntryNewYorkTime);
 
-        System.assertEquals('2. Mon 11/20 8:30am to 5:00pm', closedEntryKolkataTime);
+        System.assertEquals('2. Mon 11/20 8:30am - 5:00pm', closedEntryKolkataTime);
     }
 
     @isTest

--- a/src/classes/SlashclockUtilTest.cls
+++ b/src/classes/SlashclockUtilTest.cls
@@ -2,6 +2,54 @@
 private class SlashclockUtilTest {
 
     @isTest
+    private static void formatEntry() {
+
+        // Given
+        TimeEntry__c openEntry = new TimeEntry__c(
+                SlackUserId__c = 'em',
+                SlackTeamId__c = 'cee',
+                StartTime__c = DateTime.newInstanceGmt(2017, 11, 21, 3, 0, 0),
+                EndTime__c = null);
+
+        TimeEntry__c closedEntry = new TimeEntry__c(
+                SlackUserId__c = 'em',
+                SlackTeamId__c = 'cee',
+                StartTime__c = DateTime.newInstanceGmt(2017, 11, 20, 3, 0, 0),
+                EndTime__c = DateTime.newInstanceGmt(2017, 11, 20, 11, 30, 0));
+
+        Integer index = 2;
+
+        String newYorkTimeZoneSidKey = 'America/New_York';
+        String kolkataTimeZoneSidKey = 'Asia/Kolkata';
+
+        // When
+        Test.startTest();
+
+        String openEntryNewYorkTime = SlashclockUtil.formatEntry(
+                openEntry, index, newYorkTimeZoneSidKey);
+        
+        String openEntryKolkataTime = SlashclockUtil.formatEntry(
+                openEntry, index, kolkataTimeZoneSidKey);
+        
+        String closedEntryNewYorkTime = SlashclockUtil.formatEntry(
+                closedEntry, index, newYorkTimeZoneSidKey);
+        
+        String closedEntryKolkataTime = SlashclockUtil.formatEntry(
+                closedEntry, index, kolkataTimeZoneSidKey);
+
+        // Then
+        Test.stopTest();
+
+        System.assertEquals('2. Mon 11/20 10:00pm to now', openEntryNewYorkTime);
+
+        System.assertEquals('2. Tue 11/21 8:30am to now', openEntryKolkataTime);
+
+        System.assertEquals('2. Sun 11/20 10:00pm to 6:30am', closedEntryNewYorkTime);
+
+        System.assertEquals('2. Mon 11/20 8:30am to 5:00pm', closedEntryKolkataTime);
+    }
+
+    @isTest
     private static void emcee20170703SevenDayReportItems() {
 
         // Given

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -24,4 +24,12 @@
         <shortDescription>SlashclockSliceSuccess</shortDescription>
         <value>Time sliced!</value>
     </labels>
+    <labels>
+        <fullName>SlashclockStrikeSuccess</fullName>
+        <categories>slashclock</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>SlashclockStrikeSuccess</shortDescription>
+        <value>Entry deleted.\n{0}</value>
+    </labels>
 </CustomLabels>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -30,6 +30,7 @@
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>SlashclockStrikeSuccess</shortDescription>
-        <value>Entry deleted.\n{0}</value>
+        <value>Entry deleted.
+{0}</value>
     </labels>
 </CustomLabels>

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
     <labels>
+        <fullName>SlashclockEntriesNoEntries</fullName>
+        <categories>slashclock</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>SlashclockEntriesNoEntries</shortDescription>
+        <value>I couldn&apos;t find any time entries for you from the last seven days!</value>
+    </labels>
+    <labels>
+        <fullName>SlashclockEntriesOpening</fullName>
+        <categories>slashclock</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>SlashclockEntriesOpening</shortDescription>
+        <value>Here&apos;s what you&apos;ve clocked over the last seven days.</value>
+    </labels>
+    <labels>
         <fullName>SlashclockSliceSuccess</fullName>
         <categories>slashclock</categories>
         <language>en_US</language>

--- a/src/package.xml
+++ b/src/package.xml
@@ -20,6 +20,8 @@
         <members>SlashCommandUtil</members>
         <members>Slashclock</members>
         <members>SlashclockCallbackController</members>
+        <members>SlashclockEntriesCommand</members>
+        <members>SlashclockEntriesCommandTest</members>
         <members>SlashclockException</members>
         <members>SlashclockInCommand</members>
         <members>SlashclockInCommandTest</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -38,6 +38,8 @@
         <members>SlashclockServiceTest</members>
         <members>SlashclockSliceCommand</members>
         <members>SlashclockSliceCommandTest</members>
+        <members>SlashclockStrikeCommand</members>
+        <members>SlashclockStrikeCommandTest</members>
         <members>SlashclockUtil</members>
         <members>SlashclockUtilTest</members>
         <members>SmartMock</members>


### PR DESCRIPTION
This pr introduces the two commands below.

* `/clock entries` will list all time entries from the last seven days in reverse chronological order based on Start Time. Each listed entry will have a numeric index next to it, for use with the `/clock strike` command.
* `/clock strike` will delete the time entry at the given index, as listed by `/clock entries`