### PR TITLE
/clock report last week

### DIFF
--- a/src/classes/SlackUtil.cls
+++ b/src/classes/SlackUtil.cls
@@ -1,5 +1,9 @@
 public with sharing class SlackUtil {
 
+    public static String bold(String value) {
+        return '*' + value + '*';
+    }
+
     public static String format(SlashclockReport report) {
 
         // Initialize the lines of text to render
@@ -15,10 +19,6 @@ public with sharing class SlackUtil {
 
         // Add the formatted summary line
         lines.add(format(report.getSummaryItem()));
-
-        // Add the code block escape lines
-        lines.add('```');
-        lines.add(0, '```');
 
         // Return the formatted
         return String.join(lines, '\n');

--- a/src/classes/SlackUtil.cls
+++ b/src/classes/SlackUtil.cls
@@ -8,6 +8,8 @@ public with sharing class SlackUtil {
 
         // Initialize the lines of text to render
         List<String> lines = new List<String>();
+
+        lines.add(Label.SlashclockReportOpening);
         
         // Go through every daily item in the report, and format the item
         for (SlashclockReportItem eachItem : report.getItems()) {

--- a/src/classes/SlackUtil.cls
+++ b/src/classes/SlackUtil.cls
@@ -17,7 +17,7 @@ public with sharing class SlackUtil {
         }
 
         // Add the summary line break
-        lines.add('==========');
+        lines.add(SlashclockReport.DEFAULT_SUMMARY_SEPARATOR);
 
         // Add the formatted summary line
         lines.add(format(report.getSummaryItem()));

--- a/src/classes/SlashclockReportCommand.cls
+++ b/src/classes/SlashclockReportCommand.cls
@@ -1,11 +1,15 @@
 public with sharing class SlashclockReportCommand implements Slashclock.Command {
 
+    private DateTime endTime;
+    private Boolean forLastWeek;
     private String teamId;
     private String userId;
 
     public SlashclockReportCommand() {
         this.userId = null;
         this.teamId = null;
+        this.endTime = DateTime.now();
+        this.forLastWeek = false;
     }
 
     public Slashclock.CommandResult execute() {
@@ -13,10 +17,18 @@ public with sharing class SlashclockReportCommand implements Slashclock.Command 
         // Initialize the result
         Slashclock.CommandResult result = new Slashclock.CommandResult();
 
-        // Clock in via service
+        // Get the service
         SlashclockService slashclock =
                 SlashclockService.getInstance(this.userId, this.teamId);
-        SlashclockReport report = slashclock.report(DateTime.now());
+
+        // Adjust for last week if needed
+        if (this.forLastWeek) {
+            this.endTime = slashclock.getStartOfWeek(
+                    this.endTime).addSeconds(-1);
+        }
+
+        // Generate the report
+        SlashclockReport report = slashclock.report(this.endTime);
         result.setMessage(SlackUtil.format(report));
         result.setSuccess(true);
 
@@ -27,6 +39,13 @@ public with sharing class SlashclockReportCommand implements Slashclock.Command 
     public Slashclock.Command load(SlashCommand__c command) {
         this.userId = command.SlackUserId__c;
         this.teamId = command.SlackTeamId__c;
+
+        // Set the end time to the start of this week, so that the report
+        // will contain all entries from the previous week.
+        if (command.Text__c.endsWith('last week')) {
+            this.forLastWeek = true;
+        }
+
         return this;
     }
 

--- a/src/classes/SlashclockReportItem.cls
+++ b/src/classes/SlashclockReportItem.cls
@@ -67,7 +67,7 @@ public with sharing class SlashclockReportItem {
 
         // Initialize the known parts of the string
         List<String> itemParts = new List<String> {
-            this.label, this.duration.formatH()
+            this.label, SlackUtil.bold(this.duration.formatH())
         };
 
         // Add a part for the slices if we have any slices

--- a/src/classes/SlashclockReportItemTest.cls
+++ b/src/classes/SlashclockReportItemTest.cls
@@ -128,7 +128,7 @@ private class SlashclockReportItemTest {
         // Then
         Test.stopTest();
 
-        System.assertEquals('noop 3h', formatted);
+        System.assertEquals('noop *3h*', formatted);
     }
 
     @isTest
@@ -158,7 +158,7 @@ private class SlashclockReportItemTest {
         // Then
         Test.stopTest();
 
-        System.assertEquals('Fri 3h (1h TEST)', formatted);
+        System.assertEquals('Fri *3h* (1h TEST)', formatted);
     }
 
     @isTest
@@ -194,7 +194,7 @@ private class SlashclockReportItemTest {
         // Then
         Test.stopTest();
 
-        System.assertEquals('Fri 3h (2h TEST)', formatted);
+        System.assertEquals('Fri *3h* (2h TEST)', formatted);
     }
 
     @isTest
@@ -230,6 +230,6 @@ private class SlashclockReportItemTest {
         // Then
         Test.stopTest();
 
-        System.assertEquals('Fri 3h (1.5h bar; 1h foo)', formatted);
+        System.assertEquals('Fri *3h* (1.5h bar; 1h foo)', formatted);
     }
 }

--- a/src/classes/SlashclockReportTest.cls
+++ b/src/classes/SlashclockReportTest.cls
@@ -75,11 +75,11 @@ private class SlashclockReportTest {
         Test.stopTest();
 
         List<String> expectedLines = new List<String> {
-            'Mon 8h',
-            'Tue 7h (1h trails)',
-            'Wed 9h (1h cert; 0.5h trails)',
+            'Mon *8h*',
+            'Tue *7h* (1h trails)',
+            'Wed *9h* (1h cert; 0.5h trails)',
             SlashclockReport.DEFAULT_SUMMARY_SEPARATOR,
-            'SUM 24h (1h cert; 1.5h trails)'
+            'SUM *24h* (1h cert; 1.5h trails)'
         };
 
         System.assertEquals(String.join(expectedLines, '\n'), formatted);

--- a/src/classes/SlashclockUtilTest.cls
+++ b/src/classes/SlashclockUtilTest.cls
@@ -86,13 +86,13 @@ private class SlashclockUtilTest {
 
         System.assertEquals(7, items.size(), 'number of report items');
 
-        System.assertEquals('Mon 0h', items[0].format());
-        System.assertEquals('Tue 9h', items[1].format());
-        System.assertEquals('Wed 9.5h (1.5h apex)', items[2].format());
-        System.assertEquals('Thu 0h', items[3].format());
-        System.assertEquals('Fri 0h', items[4].format());
-        System.assertEquals('Sat 0h', items[5].format());
-        System.assertEquals('Sun 0h', items[6].format());
+        System.assertEquals('Mon *0h*', items[0].format());
+        System.assertEquals('Tue *9h*', items[1].format());
+        System.assertEquals('Wed *9.5h* (1.5h apex)', items[2].format());
+        System.assertEquals('Thu *0h*', items[3].format());
+        System.assertEquals('Fri *0h*', items[4].format());
+        System.assertEquals('Sat *0h*', items[5].format());
+        System.assertEquals('Sun *0h*', items[6].format());
     }
 
     @testSetup

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -17,6 +17,14 @@
         <value>Here&apos;s what you&apos;ve clocked over the last seven days.</value>
     </labels>
     <labels>
+        <fullName>SlashclockReportOpening</fullName>
+        <categories>slashclock</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>SlashclockEntriesOpening</shortDescription>
+        <value>Below are your stats for the week.</value>
+    </labels>
+    <labels>
         <fullName>SlashclockSliceSuccess</fullName>
         <categories>slashclock</categories>
         <language>en_US</language>


### PR DESCRIPTION
This pr enhances the `/clock report` command by accepting an optional `last week` parameter. Another significant change is that the formatting of the report was updated to be in normal text, with the per-line total hours **bolded**.