### PR TITLE
Round numbers in report

### DIFF
--- a/src/classes/DateTimeUtil.cls
+++ b/src/classes/DateTimeUtil.cls
@@ -49,6 +49,26 @@ public with sharing class DateTimeUtil {
                 dateValue, timeValue, TimeZone.getTimeZone(timeZoneSidKey));
     }
 
+    /**
+     * This functions similar to the `Decimal.setScale(Integer)` method,
+     * where a given `Datetime` value is always rounded up to the nearest
+     * increment of the given scale in minutes.
+     *
+     * For example, if the scale is 3 minutes, and the given value has a time
+     * component of 2:46pm, the returned value should bumped up to 2:48pm.
+     * if the given scale was instead 15 minutes, for the same given value
+     * the returned value should be bumped up to 3:00pm.
+     *
+     * @param value The `Datetime` value to round
+     *
+     * @param scale The number of minutes per increment
+     *
+     * @return the value, rounded up to the next whole increment
+     */
+    public static Datetime setScale(Datetime value, Integer scale) {
+        return value;
+    }
+
     public static Date startOfWeek(Date value, Weekday firstDayOfWeek) {
 
         // Figure out the weekday index of the given date

--- a/src/classes/DateTimeUtil.cls
+++ b/src/classes/DateTimeUtil.cls
@@ -66,7 +66,20 @@ public with sharing class DateTimeUtil {
      * @return the value, rounded up to the next whole increment
      */
     public static Datetime setScale(Datetime value, Integer scale) {
-        return value;
+        
+        // Figure out the base number of minutes we're starting with
+        Long seconds = value.getTime() / 1000;
+        Long minutes = seconds / 60;
+
+        // Round up
+        Long remainder = Math.mod(minutes, scale);
+        
+        if (remainder > 0) {
+            minutes = minutes + scale - remainder;
+        }
+
+        // Return the value rounded up
+        return Datetime.newInstance(minutes * 60 * 1000);
     }
 
     public static Date startOfWeek(Date value, Weekday firstDayOfWeek) {

--- a/src/classes/DateTimeUtilTest.cls
+++ b/src/classes/DateTimeUtilTest.cls
@@ -43,6 +43,88 @@ private class DateTimeUtilTest {
     }
 
     @isTest
+    private static void setScale6() {
+
+        // Given
+        Map<Datetime, Datetime> expectedMap = new Map<Datetime, Datetime> {
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 0, 0) =>
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 0, 0),
+            
+            Datetime.newInstanceGmt(2018, 1, 23, 23, 58, 30) =>
+            Datetime.newInstanceGmt(2018, 1, 24, 0, 0, 0),
+            
+            Datetime.newInstanceGmt(2018, 1, 23, 23, 49, 0) =>
+            Datetime.newInstanceGmt(2018, 1, 23, 23, 54, 0),
+            
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 30, 0) =>
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 30, 0)
+        };
+
+        Integer scale = 6;  // for this test
+
+        // When
+        Test.startTest();
+
+        Map<Datetime, Datetime> actualMap = new Map<Datetime, Datetime>();
+
+        for (Datetime eachGivenValue : expectedMap.keySet()) {
+            actualMap.put(eachGivenValue,
+                    DatetimeUtil.setScale(eachGivenValue, scale));
+        }
+
+        // Then
+        Test.stopTest();
+
+        for (Datetime eachGivenValue : expectedMap.keySet()) {
+            Datetime expected = expectedMap.get(eachGivenValue);
+            Datetime actual = actualMap.get(eachGivenValue);
+
+            System.assertEquals(expected, actual, eachGivenValue);
+        }
+    }
+
+    @isTest
+    private static void setScale15() {
+
+        // Given
+        Map<Datetime, Datetime> expectedMap = new Map<Datetime, Datetime> {
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 0, 0) =>
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 0, 0),
+            
+            Datetime.newInstanceGmt(2018, 1, 23, 23, 58, 30) =>
+            Datetime.newInstanceGmt(2018, 1, 24, 0, 0, 0),
+            
+            Datetime.newInstanceGmt(2018, 1, 23, 23, 1, 0) =>
+            Datetime.newInstanceGmt(2018, 1, 23, 23, 15, 0),
+            
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 35, 0) =>
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 45, 0)
+        };
+
+        Integer scale = 15;  // for this test
+
+        // When
+        Test.startTest();
+
+        Map<Datetime, Datetime> actualMap = new Map<Datetime, Datetime>();
+
+        for (Datetime eachGivenValue : expectedMap.keySet()) {
+            actualMap.put(eachGivenValue,
+                    DatetimeUtil.setScale(eachGivenValue, scale));
+        }
+
+        // Then
+        Test.stopTest();
+
+        for (Datetime eachGivenValue : expectedMap.keySet()) {
+            Datetime expected = expectedMap.get(eachGivenValue);
+            Datetime actual = actualMap.get(eachGivenValue);
+
+            System.assertEquals(expected, actual, eachGivenValue);
+        }
+    }
+
+    @isTest
     private static void getWeekday() {
 
         // Given

--- a/src/classes/DateTimeUtilTest.cls
+++ b/src/classes/DateTimeUtilTest.cls
@@ -2,6 +2,47 @@
 private class DateTimeUtilTest {
 
     @isTest
+    private static void setScale3() {
+
+        // Given
+        Map<Datetime, Datetime> expectedMap = new Map<Datetime, Datetime> {
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 0, 0) =>
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 0, 0),
+            
+            Datetime.newInstanceGmt(2018, 1, 23, 23, 58, 30) =>
+            Datetime.newInstanceGmt(2018, 1, 24, 0, 0, 0),
+            
+            Datetime.newInstanceGmt(2018, 1, 23, 23, 59, 0) =>
+            Datetime.newInstanceGmt(2018, 1, 24, 0, 0, 0),
+            
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 30, 0) =>
+            Datetime.newInstanceGmt(2018, 1, 23, 12, 30, 0)
+        };
+
+        Integer scale = 3;  // for this test
+
+        // When
+        Test.startTest();
+
+        Map<Datetime, Datetime> actualMap = new Map<Datetime, Datetime>();
+
+        for (Datetime eachGivenValue : expectedMap.keySet()) {
+            actualMap.put(eachGivenValue,
+                    DatetimeUtil.setScale(eachGivenValue, scale));
+        }
+
+        // Then
+        Test.stopTest();
+
+        for (Datetime eachGivenValue : expectedMap.keySet()) {
+            Datetime expected = expectedMap.get(eachGivenValue);
+            Datetime actual = actualMap.get(eachGivenValue);
+
+            System.assertEquals(expected, actual, eachGivenValue);
+        }
+    }
+
+    @isTest
     private static void getWeekday() {
 
         // Given

--- a/src/classes/SlashclockReportCommand.cls
+++ b/src/classes/SlashclockReportCommand.cls
@@ -26,6 +26,11 @@ public with sharing class SlashclockReportCommand implements Slashclock.Command 
             this.endTime = slashclock.getStartOfWeek(
                     this.endTime).addSeconds(-1);
         }
+        else {
+
+            // TODO: Make the scale configurable per user
+            this.endTime = DatetimeUtil.setScale(this.endTime, 6);
+        }
 
         // Generate the report
         SlashclockReport report = slashclock.report(this.endTime);


### PR DESCRIPTION
This pr resolves #29 by rounding numbers in reports with the assumption that open time entries should always have an end time that is rounded up to the next 6-minute or 0.1-hour increment. This increment is not configurable although the code that calculates the rounded value can support any increment in minutes.

What's important to note is that this only rounds _open_ entries. So, for example, if a closed entry accounted for 7.25 hours, and the open entry currently shows a duration of 14 minutes, the total reported duration would show **7.55** hours. This value is the sum of the 7.25 hours from the closed entry plus the 14 minutes rounded up to 18 minutes or 0.3 hours.