### PR TITLE
Slice summary with entries

### DIFF
--- a/src/classes/RelativeTestService.cls
+++ b/src/classes/RelativeTestService.cls
@@ -30,6 +30,18 @@ public class RelativeTestService {
         Datetime twoDaysAgo = this.reference.addDays(-2);
         Datetime oneDaysAgo = this.reference.addDays(-1);
         Datetime thirtyMinutesAgo = this.reference.addMinutes(-30);
+        
+        Date yesterday = this.referenceDate.addDays(-1);
+        
+        Datetime yesterdayNineFifteen =
+                DateTimeUtil.newDatetime(
+                        yesterday, Time.newInstance(9, 15, 0, 0),
+                        this.timeZoneSidKey);
+        
+        Datetime yesterdayTenFifteen =
+                DateTimeUtil.newDatetime(
+                        yesterday, Time.newInstance(10, 15, 0, 0),
+                        this.timeZoneSidKey);
 
         // Create accounts
         Account board = new Account(
@@ -53,7 +65,15 @@ public class RelativeTestService {
                 LastName = 'Kick (TEST)',
                 SlackuserId__c = 'kick');
 
+        Contact skate = new Contact(
+                AccountId = board.Id,
+                FirstName = 'Slick',
+                LastName = 'Skate (TEST)',
+                SlackUserId__c = 'skate',
+                TimeZoneSidKey__c = this.timeZoneSidKey);
+
         insert new List<Contact> {
+            skate,
             kick,
             flip
         };
@@ -69,7 +89,21 @@ public class RelativeTestService {
                 SlackUserId__c = 'flip',
                 SlackTeamId__c = 'board');
 
+        TimeEntry__c skateboardYesterdayNineFifteen = new TimeEntry__c(
+                StartTime__c = yesterdayNineFifteen,
+                EndTime__c = yesterdayNineFifteen.addMinutes(30),
+                SlackUserId__c = 'skate',
+                SlackTeamId__c = 'board');
+
+        TimeEntry__c skateboardYesterdayTenFifteen = new TimeEntry__c(
+                StartTime__c = yesterdayTenFifteen,
+                EndTime__c = yesterdayTenFifteen.addHours(7).addMinutes(30),
+                SlackUserId__c = 'skate',
+                SlackTeamId__c = 'board');
+
         insert new List<TimeEntry__c> {
+            skateboardYesterdayNineFifteen,
+            skateboardYesterdayTenFifteen,
             kickboard2DaysAgo,
             flipboard30mAgo
         };

--- a/src/classes/SlackService.cls
+++ b/src/classes/SlackService.cls
@@ -48,7 +48,11 @@ public with sharing class SlackService {
 
         // Look for a existing contact
         List<Contact> userContacts = [
-            SELECT Id, SlackUserId__c, TimeZoneSidKey__c
+            SELECT
+                SlackTeamId__c,
+                SlackUserId__c,
+                TimeZoneSidKey__c,
+                Id
             FROM Contact
             WHERE AccountId = :findOrCreateAccount().Id
                 AND SlackUserId__c = :userId

--- a/src/classes/SlashclockEntriesCommand.cls
+++ b/src/classes/SlashclockEntriesCommand.cls
@@ -14,12 +14,12 @@ public with sharing class SlashclockEntriesCommand implements Slashclock.Command
      */
     private Integer numberOfDays;
 
-    private String teamId;
-    private String userId;
+    private Contact userContact;
 
     public SlashclockEntriesCommand() {
-        this.userId = null;
-        this.teamId = null;
+        this.userContact = null;
+
+        // TODO: Make configurable
         this.numberOfDays = 7;
         this.currentTime = DateTime.now();
     }
@@ -32,7 +32,7 @@ public with sharing class SlashclockEntriesCommand implements Slashclock.Command
         // Clock in via service
         try {
             SlashclockService slashclock =
-                    SlashclockService.getInstance(this.userId, this.teamId);
+                    SlashclockService.getInstance(this.userContact);
 
             List<TimeEntry__c> entries = slashclock.getTimeEntriesSince(
                     this.currentTime.addDays(-1 * numberOfDays));
@@ -50,14 +50,9 @@ public with sharing class SlashclockEntriesCommand implements Slashclock.Command
 
     public Slashclock.Command load(SlashCommand__c command) {
 
-        // Remember the Slack User ID and Team ID,
-        // then locate the contact and the time zone
-        this.userId = command.SlackUserId__c;
-        this.teamId = command.SlackTeamId__c;
-        
-        // Figure out the time zone
-        SlackService slacker = SlackService.getInstance(this.teamId);
-        Contact userContact = slacker.findOrCreateContact(this.userId);
+        // Locate the contact and the time zone
+        SlackService slacker = SlackService.getInstance(command.SlackTeamId__c);
+        this.userContact = slacker.findOrCreateContact(command.SlackUserId__c);
         
         // Return the fully loaded SlashClock command!
         return this;

--- a/src/classes/SlashclockEntriesCommandTest.cls
+++ b/src/classes/SlashclockEntriesCommandTest.cls
@@ -47,5 +47,52 @@ private class SlashclockEntriesCommandTest {
         System.assert(
                 givenMessageParts.get(2).endsWith('9:15am - 9:45am'),
                 givenMessageParts.get(2) + ' should end with ' + '9:15am - 9:45am');
+
+        // When
+        Test.startTest();
+
+        Slashclock.Command sliceCommand = new SlashclockSliceCommand();
+
+        sliceCommand.load(
+                new SlashCommand__c(
+                        SlackUserId__c = skate.SlackUserId__c,
+                        SlackTeamId__c = skate.Account.SlackTeamId__c,
+                        Text__c = 'slice 30 minutes fun',
+                        Command__c = '/clock'));
+
+        Slashclock.CommandResult sliceResult = sliceCommand.execute();
+
+        // Then
+        Test.stopTest();
+
+        Slashclock.Command thenCommand = new SlashclockEntriesCommand();
+        
+        thenCommand.load(
+                new SlashCommand__c(
+                        SlackUserId__c = skate.SlackUserId__c,
+                        SlackTeamId__c = skate.Account.SlackTeamId__c,
+                        Text__c = 'entries',
+                        Command__c = '/clock'));
+
+        Slashclock.CommandResult thenResult = thenCommand.execute();
+
+        List<String> thenMessageParts = thenResult.getMessage().split('\n');
+
+        System.assertEquals(
+                'Here\'s what you\'ve clocked over the last seven days.',
+                thenMessageParts.get(0),
+                'thenMessageParts.get(0)');
+
+        String thenEntry1Ending = '10:15am - 5:45pm (0.5h fun)';
+
+        System.assert(
+                givenMessageParts.get(1).endsWith(thenEntry1Ending),
+                givenMessageParts.get(1) + ' should end with ' + thenEntry1Ending);
+
+        String thenEntry2Ending = '9:15am - 9:45am';
+
+        System.assert(
+                givenMessageParts.get(2).endsWith(thenEntry2Ending),
+                givenMessageParts.get(2) + ' should end with ' + thenEntry2Ending);
     }
 }

--- a/src/classes/SlashclockEntriesCommandTest.cls
+++ b/src/classes/SlashclockEntriesCommandTest.cls
@@ -42,10 +42,10 @@ private class SlashclockEntriesCommandTest {
 
         System.assert(
                 givenMessageParts.get(1).endsWith('10:15am - 5:45pm'),
-                givenMessageParts.get(1) + ' should end without slices');
+                givenMessageParts.get(1) + ' should end with ' + '10:15am - 5:45pm');
 
         System.assert(
-                givenMessageParts.get(2).endsWith('9:15am - 9:45pm'),
-                givenMessageParts.get(2) + ' should end without slices');
+                givenMessageParts.get(2).endsWith('9:15am - 9:45am'),
+                givenMessageParts.get(2) + ' should end with ' + '9:15am - 9:45am');
     }
 }

--- a/src/classes/SlashclockEntriesCommandTest.cls
+++ b/src/classes/SlashclockEntriesCommandTest.cls
@@ -69,10 +69,16 @@ private class SlashclockEntriesCommandTest {
         // When
         Test.startTest();
 
-        insert new TimeSlice__c(
-                NumberOfMinutes__c = 30,
-                Tag__c = 'fun',
-                TimeEntry__c = givenEntries[0].Id);
+        Slashclock.Command sliceCommand = new SlashclockSliceCommand();
+
+        sliceCommand.load(
+                new SlashCommand__c(
+                        SlackUserId__c = skate.SlackUserId__c,
+                        SlackTeamId__c = skate.Account.SlackTeamId__c,
+                        Text__c = 'slice 30 minutes fun',
+                        Command__c = '/clock'));
+
+        Slashclock.CommandResult sliceResult = sliceCommand.execute();
 
         // Then
         Test.stopTest();

--- a/src/classes/SlashclockEntriesCommandTest.cls
+++ b/src/classes/SlashclockEntriesCommandTest.cls
@@ -22,6 +22,24 @@ private class SlashclockEntriesCommandTest {
             WHERE LastName = 'Skate (TEST)'
         ];
 
+        List<TimeEntry__c> givenEntries = [
+            SELECT
+                StartTime__c,
+                EndTime__c,
+                Id
+            FROM TimeEntry__c
+            WHERE
+                SlackTeamId__c = :skate.Account.SlackTeamId__c AND
+                SlackUserId__c = :skate.SlackUserId__c
+            ORDER BY StartTime__c DESC
+        ];
+
+        List<TimeSlice__c> givenSlices = [
+            SELECT Id
+            FROM TimeSlice__c
+            WHERE TimeEntry__c IN :givenEntries
+        ];
+
         Slashclock.Command givenCommand = new SlashclockEntriesCommand();
         
         givenCommand.load(
@@ -51,19 +69,24 @@ private class SlashclockEntriesCommandTest {
         // When
         Test.startTest();
 
-        Slashclock.Command sliceCommand = new SlashclockSliceCommand();
-
-        sliceCommand.load(
-                new SlashCommand__c(
-                        SlackUserId__c = skate.SlackUserId__c,
-                        SlackTeamId__c = skate.Account.SlackTeamId__c,
-                        Text__c = 'slice 30 minutes fun',
-                        Command__c = '/clock'));
-
-        Slashclock.CommandResult sliceResult = sliceCommand.execute();
+        insert new TimeSlice__c(
+                NumberOfMinutes__c = 30,
+                Tag__c = 'fun',
+                TimeEntry__c = givenEntries[0].Id);
 
         // Then
         Test.stopTest();
+
+        List<TimeSlice__c> thenSlices = [
+            SELECT
+                NumberOfMinutes__c,
+                Tag__c,
+                Id
+            FROM TimeSlice__c
+            WHERE TimeEntry__c IN :givenEntries
+        ];
+
+        System.assertEquals(1, thenSlices.size(), 'number of slices');
 
         Slashclock.Command thenCommand = new SlashclockEntriesCommand();
         
@@ -86,13 +109,13 @@ private class SlashclockEntriesCommandTest {
         String thenEntry1Ending = '10:15am - 5:45pm (0.5h fun)';
 
         System.assert(
-                givenMessageParts.get(1).endsWith(thenEntry1Ending),
-                givenMessageParts.get(1) + ' should end with ' + thenEntry1Ending);
+                thenMessageParts.get(1).endsWith(thenEntry1Ending),
+                thenMessageParts.get(1) + ' should end with ' + thenEntry1Ending);
 
         String thenEntry2Ending = '9:15am - 9:45am';
 
         System.assert(
-                givenMessageParts.get(2).endsWith(thenEntry2Ending),
-                givenMessageParts.get(2) + ' should end with ' + thenEntry2Ending);
+                thenMessageParts.get(2).endsWith(thenEntry2Ending),
+                thenMessageParts.get(2) + ' should end with ' + thenEntry2Ending);
     }
 }

--- a/src/classes/SlashclockEntriesCommandTest.cls
+++ b/src/classes/SlashclockEntriesCommandTest.cls
@@ -1,3 +1,51 @@
 @isTest
 private class SlashclockEntriesCommandTest {
+
+    @testSetup
+    private static void setup() {
+        RelativeTestService.getInstance(
+                Datetime.now(), 'Europe/London').setup();
+    }
+
+    @isTest
+    private static void clockEntriesAfterSlice30Minutes() {
+
+        // Given
+        Contact skate = [
+            SELECT
+                Account.SlackTeamId__c,
+                AccountId,
+                SlackUserId__c,
+                TimeZoneSidKey__c,
+                Id
+            FROM Contact
+            WHERE LastName = 'Skate (TEST)'
+        ];
+
+        Slashclock.Command givenCommand = new SlashclockEntriesCommand();
+        
+        givenCommand.load(
+                new SlashCommand__c(
+                        SlackUserId__c = skate.SlackUserId__c,
+                        SlackTeamId__c = skate.Account.SlackTeamId__c,
+                        Text__c = 'entries',
+                        Command__c = '/clock'));
+
+        Slashclock.CommandResult givenResult = givenCommand.execute();
+
+        List<String> givenMessageParts = givenResult.getMessage().split('\n');
+
+        System.assertEquals(
+                'Here\'s what you\'ve clocked over the last seven days.',
+                givenMessageParts.get(0),
+                'givenMessageParts.get(0)');
+
+        System.assert(
+                givenMessageParts.get(1).endsWith('10:15am - 5:45pm'),
+                givenMessageParts.get(1) + ' should end without slices');
+
+        System.assert(
+                givenMessageParts.get(2).endsWith('9:15am - 9:45pm'),
+                givenMessageParts.get(2) + ' should end without slices');
+    }
 }

--- a/src/classes/SlashclockReportItem.cls
+++ b/src/classes/SlashclockReportItem.cls
@@ -2,12 +2,12 @@ public with sharing class SlashclockReportItem {
 
     private Time2 duration;
     private String label;
-    private Map<String, SlashclockReportSlice> slicesByTag;
+    private SlashclockSliceList slices;
 
     private SlashclockReportItem(String label, Time2 duration) {
         this.label = label;
         this.duration = duration;
-        this.slicesByTag = new Map<String, SlashclockReportSlice>();
+        this.slices = new SlashclockSliceList();
     }
 
     public SlashclockReportItem add(SlashclockReportItem other) {
@@ -42,12 +42,7 @@ public with sharing class SlashclockReportItem {
     }
 
     public void addSlice(SlashclockReportSlice slice) {
-        if (this.slicesByTag.containsKey(slice.getTag())) {
-            this.slicesByTag.get(slice.getTag()).increase(slice.getDuration());
-        }
-        else {
-            this.slicesByTag.put(slice.getTag(), slice);
-        }
+        this.slices.add(slice);
     }
 
     /**
@@ -71,29 +66,12 @@ public with sharing class SlashclockReportItem {
         };
 
         // Add a part for the slices if we have any slices
-        if (slicesByTag.size() > 0) {
-            itemParts.add(formatSlices(this.slicesByTag));
+        if (slices.size() > 0) {
+            itemParts.add(this.slices.format());
         }
 
         // Return the parts joined by spaces
         return String.join(itemParts, ' ');
-    }
-
-    public static String formatSlices(Map<String, SlashclockReportSlice> slicesByTag) {
-
-        // Initialize the formatted slice parts to join and return
-        List<String> sliceParts = new List<String>();
-        
-        List<String> sliceTags = new List<String>(slicesByTag.keySet());
-        sliceTags.sort();
-
-        for (String tag : sliceTags) {
-            SlashclockReportSlice eachSlice = slicesByTag.get(tag);
-            sliceParts.add(eachSlice.format());
-        }
-
-        // Join and return the formatted slices
-        return '(' + String.join(sliceParts, '; ') + ')';
     }
 
     public Time2 getDuration() {
@@ -105,11 +83,11 @@ public with sharing class SlashclockReportItem {
     }
 
     public SlashclockReportSlice getSlice(String tag) {
-        return this.slicesByTag.get(tag);
+        return this.slices.get(tag);
     }
 
     public List<SlashclockReportSlice> getSlices() {
-        return this.slicesByTag.values();
+        return this.slices.values();
     }
 
     public static SlashclockReportItem newInstance(DateTime startTime, String timeZoneSidKey, Time2 duration) {

--- a/src/classes/SlashclockService.cls
+++ b/src/classes/SlashclockService.cls
@@ -35,6 +35,15 @@ public with sharing class SlashclockService {
         this.firstDayOfWeek = Weekday.MONDAY;
     }
 
+    public SlashclockService(Contact userContact) {
+        this.userId = userContact.SlackUserId__c;
+        this.teamId = userContact.SlackTeamId__c;
+        this.timeZoneSidKey = userContact.TimeZoneSidKey__c;
+        
+        // TODO: Make dynamic based on Slack user preference
+        this.firstDayOfWeek = Weekday.MONDAY;
+    }
+
     /**
      * @param startTime
      *            The time at which the user clocked in
@@ -242,6 +251,10 @@ public with sharing class SlashclockService {
 
     public static SlashclockService getInstance(String userId, String teamId) {
         return new SlashclockService(userId, teamId);
+    }
+
+    public static SlashclockService getInstance(Contact userContact) {
+        return new SlashclockService(userContact);
     }
 
     public TimeEntry__c getLastTimeEntry() {

--- a/src/classes/SlashclockService.cls
+++ b/src/classes/SlashclockService.cls
@@ -185,7 +185,19 @@ public with sharing class SlashclockService {
      * @return a formatted string showing the entry's info and its index
      */
     public String formatEntry(TimeEntry__c entry, Integer index) {
-        return SlashclockUtil.formatEntry(entry, index, this.timeZoneSidKey);
+        
+        // Always start with the standard entry details
+        String value = SlashclockUtil.formatEntry(entry, index, this.timeZoneSidKey);
+
+        // Add slice information if slices are present
+        if (entry.TimeSlices__r.size() > 0) {
+            SlashclockSliceList slices =
+                    new SlashclockSliceList(entry.TimeSlices__r);
+            
+            value += ' ' + slices.format();
+        }
+
+        return value;
     }
 
     public Time2 getClockedDuration(DateTime startTime, DateTime endTime) {

--- a/src/classes/SlashclockService.cls
+++ b/src/classes/SlashclockService.cls
@@ -232,7 +232,11 @@ public with sharing class SlashclockService {
 
     public List<TimeEntry__c> getTimeEntriesSince(DateTime startTime) {
         return [
-            SELECT Id, StartTime__c, EndTime__c
+            SELECT
+                (SELECT Id, NumberOfMinutes__c, Tag__c FROM TimeSlices__r),
+                EndTime__c,
+                StartTime__c,
+                Id
             FROM TimeEntry__c
             WHERE SlackUserId__c = :this.userId
                 AND SlackTeamId__c = :this.teamId

--- a/src/classes/SlashclockSliceList.cls
+++ b/src/classes/SlashclockSliceList.cls
@@ -1,0 +1,50 @@
+public class SlashclockSliceList {
+
+    private Map<String, SlashclockReportSlice> slicesByTag;
+
+    public SlashclockSliceList() {
+        this.slicesByTag = new Map<String, SlashclockReportSlice>();
+    }
+
+    public void add(SlashclockReportSlice slice) {
+        if (this.slicesByTag.containsKey(slice.getTag())) {
+            this.slicesByTag.get(slice.getTag()).increase(slice.getDuration());
+        }
+        else {
+            this.slicesByTag.put(slice.getTag(), slice);
+        }
+    }
+
+    public String format() {
+        return formatSlices(this.slicesByTag);
+    }
+
+    public static String formatSlices(Map<String, SlashclockReportSlice> slicesByTag) {
+
+        // Initialize the formatted slice parts to join and return
+        List<String> sliceParts = new List<String>();
+        
+        List<String> sliceTags = new List<String>(slicesByTag.keySet());
+        sliceTags.sort();
+
+        for (String tag : sliceTags) {
+            SlashclockReportSlice eachSlice = slicesByTag.get(tag);
+            sliceParts.add(eachSlice.format());
+        }
+
+        // Join and return the formatted slices
+        return '(' + String.join(sliceParts, '; ') + ')';
+    }
+
+    public SlashclockReportSlice get(String tag) {
+        return this.slicesByTag.get(tag);
+    }
+
+    public Integer size() {
+        return this.slicesByTag.size();
+    }
+
+    public List<SlashclockReportSlice> values() {
+        return this.slicesByTag.values();
+    }
+}

--- a/src/classes/SlashclockSliceList.cls
+++ b/src/classes/SlashclockSliceList.cls
@@ -6,6 +6,21 @@ public class SlashclockSliceList {
         this.slicesByTag = new Map<String, SlashclockReportSlice>();
     }
 
+    public SlashclockSliceList(List<TimeSlice__c> timeSlices) {
+
+        // Start with the defaults
+        this();
+
+        // Add every time slice
+        for (TimeSlice__c eachSlice : timeSlices) {
+            this.add(eachSlice);
+        }
+    }
+
+    public void add(TimeSlice__c timeSlice) {
+        this.add(SlashclockReportSlice.newInstance(timeSlice));
+    }
+
     public void add(SlashclockReportSlice slice) {
         if (this.slicesByTag.containsKey(slice.getTag())) {
             this.slicesByTag.get(slice.getTag()).increase(slice.getDuration());

--- a/src/classes/SlashclockSliceList.cls-meta.xml
+++ b/src/classes/SlashclockSliceList.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -194,6 +194,17 @@
         <type>Lookup</type>
     </fields>
     <fields>
+        <fullName>SlackTeamId__c</fullName>
+        <caseSensitive>false</caseSensitive>
+        <externalId>false</externalId>
+        <formula>Account.SlackTeamId__c</formula>
+        <label>Slack Team ID</label>
+        <required>false</required>
+        <trackFeedHistory>false</trackFeedHistory>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>SlackUserId__c</fullName>
         <caseSensitive>false</caseSensitive>
         <externalId>true</externalId>

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -195,12 +195,10 @@
     </fields>
     <fields>
         <fullName>SlackTeamId__c</fullName>
-        <caseSensitive>false</caseSensitive>
         <externalId>false</externalId>
         <formula>Account.SlackTeamId__c</formula>
         <label>Slack Team ID</label>
         <required>false</required>
-        <trackFeedHistory>false</trackFeedHistory>
         <type>Text</type>
         <unique>false</unique>
     </fields>

--- a/src/package.xml
+++ b/src/package.xml
@@ -47,6 +47,7 @@
         <members>SlashclockServiceTest</members>
         <members>SlashclockSliceCommand</members>
         <members>SlashclockSliceCommandTest</members>
+        <members>SlashclockSliceList</members>
         <members>SlashclockStrikeCommand</members>
         <members>SlashclockStrikeCommandTest</members>
         <members>SlashclockUnknownCommand</members>


### PR DESCRIPTION
This pr adds a parenthetical summary of sliced time when the user types **/clock entries**, just like what the user would expect to see from **/clock report**.

Also introduced with this pr is support for a user's personal time zone as stored on the user's Contact record, at least for the **/clock entries** command if not other commands. #24 is still hugely necessary to make sure all commands support not only non-East Coast time zones but also changes in a user's time zone.