### PR TITLE
Use DatabaseJockey to streamline Apex tests

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,31 +1,36 @@
-# Check to require a username to be [given as argument][1]
-#
-# [1]: https://stackoverflow.com/questions/6482377/check-existence-of-input-argument-in-a-bash-shell-script
-if [ -z "$1" ]; then
-    echo ERROR: Username argument required!
+UNPACKAGED_DIR=.sfdx/unpackaged
 
-    # [terminate and indicate error][3]
-    #
-    # [3]: https://stackoverflow.com/questions/4381618/exit-a-script-on-error
-    exit 1
+# You can create a new file config/bash.conf which holds the following content.
+# 
+#     DEFAULT_USERNAME=slashclock-mc
+#
+# This will set the default username for this script
+LOCAL_CONF=config/bash.conf
+if [ -f "$LOCAL_CONF" ]; then
+    source "$LOCAL_CONF"
 fi
 
-MDAPI_OUTPUT_DIR=.mdapi/out
+# Prompt for the username
+while [ -z "$SFDX_USERNAME" ]
+do
+    read -p "To where shall we deploy${DEFAULT_USERNAME:+ ($DEFAULT_USERNAME)}? " SFDX_USERNAME
+    SFDX_USERNAME="${SFDX_USERNAME:-$DEFAULT_USERNAME}"
+done
 
-# Delete the converted metadata output directory [if it exists][2]
-#
-# [2]: https://stackoverflow.com/questions/59838/check-if-a-directory-exists-in-a-shell-script
-if [ -d "$MDAPI_OUTPUT_DIR" ]; then
-    echo found: $MDAPI_OUTPUT_DIR
-    rm -Rv $MDAPI_OUTPUT_DIR
-    echo deleted
-else
-    echo NOT found: $MDAPI_OUTPUT_DIR
+# Print a few useful pieces of information
+echo "Username: $SFDX_USERNAME"
+
+# Delete the existing deployment metadata directory if it exists
+if [ -d "$UNPACKAGED_DIR" ]; then
+    echo "Found: $UNPACKAGED_DIR"
+    echo "Deleting..."
+    rm -R "$UNPACKAGED_DIR" || exit 1
 fi
 
-mkdir -p $MDAPI_OUTPUT_DIR
+# Convert the source
+sfdx force:source:convert -d $UNPACKAGED_DIR || exit 1
 
-# Convert the source and deploy
-sfdx force:source:convert -d "$MDAPI_OUTPUT_DIR"
-sfdx force:mdapi:deploy -d "$MDAPI_OUTPUT_DIR" -w 5 -u "$1" \
-        -l "RunLocalTests"
+# Deploy the metadata
+time sfdx force:mdapi:deploy -u $SFDX_USERNAME \
+    -d $UNPACKAGED_DIR \
+    -w 5 || exit 1

--- a/force-app/main/default/classes/DatabaseJockey.cls
+++ b/force-app/main/default/classes/DatabaseJockey.cls
@@ -15,6 +15,20 @@ public with sharing class DatabaseJockey {
     }
     
     /**
+     * Adds an sObject, such as an individual account or contact,
+     * to your organization's data.
+     *
+     * @param recordToInsert
+     *
+     * @return result from the DML operation
+     *
+     * @see https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_database.htm
+     */
+    public Database.SaveResult ins(SObject recordToInsert) {
+        return Database.insert(recordToInsert, true);
+    }
+    
+    /**
      * Adds one or more sObjects, such as individual accounts or contacts,
      * to your organization’s data.
      *
@@ -33,6 +47,20 @@ public with sharing class DatabaseJockey {
      */
     public static DatabaseJockey newInstance() {
         return new DatabaseJockey();
+    }
+
+    /**
+     * Modifies an existing sObject record, such as an individual account
+     * or contact, in your organization's data.
+     *
+     * @param recordToUpdate
+     *
+     * @return result from the DML operation
+     *
+     * @see https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_database.htm
+     */
+    public Database.SaveResult upd(SObject recordToUpdate) {
+        return Database.update(recordToUpdate, true);
     }
 
     /**

--- a/force-app/main/default/classes/DatabaseJockey.cls
+++ b/force-app/main/default/classes/DatabaseJockey.cls
@@ -1,0 +1,51 @@
+public with sharing class DatabaseJockey {
+
+    /**
+     * Deletes a list of existing sObject records, such as individual accounts
+     * or contacts, from your organization’s data.
+     *
+     * @param recordsToDelete
+     *
+     * @return results from the DML operation
+     *
+     * @see https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_database.htm
+     */
+    public List<Database.DeleteResult> del(List<SObject> recordsToDelete) {
+        return Database.delete(recordsToDelete, true);
+    }
+    
+    /**
+     * Adds one or more sObjects, such as individual accounts or contacts,
+     * to your organization’s data.
+     *
+     * @param recordsToInsert
+     *
+     * @return results from the DML operation
+     *
+     * @see https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_database.htm
+     */
+    public List<Database.SaveResult> ins(List<SObject> recordsToInsert) {
+        return Database.insert(recordsToInsert, true);
+    }
+
+    /**
+     * Modifies one or more existing sObject records, such as individual
+     * accounts or contacts, in your organization’s data.
+     *
+     * @param recordsToUpdate
+     *
+     * @return results from the DML operation
+     *
+     * @see https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_database.htm
+     */
+    public List<Database.SaveResult> upd(List<SObject> recordsToUpdate) {
+        return Database.update(recordsToUpdate, true);
+    }
+
+    /**
+     * @return a fresh jockey to perform DML operations
+     */
+    public static DatabaseJockey newInstance() {
+        return new DatabaseJockey();
+    }
+}

--- a/force-app/main/default/classes/DatabaseJockey.cls
+++ b/force-app/main/default/classes/DatabaseJockey.cls
@@ -29,6 +29,13 @@ public with sharing class DatabaseJockey {
     }
 
     /**
+     * @return a fresh jockey to perform DML operations
+     */
+    public static DatabaseJockey newInstance() {
+        return new DatabaseJockey();
+    }
+
+    /**
      * Modifies one or more existing sObject records, such as individual
      * accounts or contacts, in your organization’s data.
      *
@@ -40,12 +47,5 @@ public with sharing class DatabaseJockey {
      */
     public List<Database.SaveResult> upd(List<SObject> recordsToUpdate) {
         return Database.update(recordsToUpdate, true);
-    }
-
-    /**
-     * @return a fresh jockey to perform DML operations
-     */
-    public static DatabaseJockey newInstance() {
-        return new DatabaseJockey();
     }
 }

--- a/force-app/main/default/classes/DatabaseJockey.cls-meta.xml
+++ b/force-app/main/default/classes/DatabaseJockey.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DatabaseJockeyMock.cls
+++ b/force-app/main/default/classes/DatabaseJockeyMock.cls
@@ -1,0 +1,9 @@
+public with sharing class DatabaseJockeyMock extends SimpleStubProvider {
+
+    public static DatabaseJockey newInstance() {
+        return (DatabaseJockey)Test.createStub(
+            DatabaseJockey.class,
+            new DatabaseJockeyMock()
+        );
+    }
+}

--- a/force-app/main/default/classes/DatabaseJockeyMock.cls-meta.xml
+++ b/force-app/main/default/classes/DatabaseJockeyMock.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DatabaseJockeyTest.cls
+++ b/force-app/main/default/classes/DatabaseJockeyTest.cls
@@ -1,0 +1,28 @@
+@isTest
+private class DatabaseJockeyTest {
+
+    /** 
+     * Confirm that `newInstance` always returns a different instance
+     * of `DatabaseJockey`.
+     */
+    @isTest
+    private static void newInstancesAreDifferent() {
+
+        // Given
+        DatabaseJockey givenJockey = DatabaseJockey.newInstance();
+
+        // When
+        Test.startTest();
+
+        DatabaseJockey newJockey = DatabaseJockey.newInstance();
+
+        // Then
+        Test.stopTest();
+
+        System.assertNotEquals(
+            givenJockey,
+            newJockey,
+            'New jockey should not be the same as given jockey'
+        );
+    }
+}

--- a/force-app/main/default/classes/DatabaseJockeyTest.cls
+++ b/force-app/main/default/classes/DatabaseJockeyTest.cls
@@ -1,6 +1,34 @@
 @isTest
 private class DatabaseJockeyTest {
 
+    /**
+     * Confirm that a jockey can create an account.
+     */
+    @isTest
+    private static void insertAccount() {
+
+        // Given
+        Account acme = new Account(
+            Name = 'Acme, Inc. (TEST)'
+        );
+
+        // When
+        Test.startTest();
+
+        DatabaseJockey jockey = DatabaseJockey.newInstance();
+        List<Database.SaveResult> results = jockey.ins(
+            new List<Account> { acme }
+        );
+
+        // Then
+        Test.stopTest();
+
+        System.assert(
+            results.get(0).isSuccess(),
+            'Insert failed: ' + results.get(0).getErrors()
+        );
+    }
+
     /** 
      * Confirm that `newInstance` always returns a different instance
      * of `DatabaseJockey`.

--- a/force-app/main/default/classes/DatabaseJockeyTest.cls
+++ b/force-app/main/default/classes/DatabaseJockeyTest.cls
@@ -2,6 +2,37 @@
 private class DatabaseJockeyTest {
 
     /**
+     * Confirm that a jockey can delete an account.
+     */
+    @isTest
+    private static void deleteAccount() {
+
+        // Given
+        Account givenAcme = new Account(
+            Name = 'Acme, Inc. (TEST)'
+        );
+
+        insert givenAcme;
+
+        // When
+        Test.startTest();
+
+        DatabaseJockey jockey = DatabaseJockey.newInstance();
+
+        List<Database.DeleteResult> results = jockey.del(
+            new List<Account> { givenAcme }
+        );
+
+        // Then
+        Test.stopTest();
+
+        System.assert(
+            results.get(0).isSuccess(),
+            'Delete failed: ' + results.get(0).getErrors()
+        );
+    }
+
+    /**
      * Confirm that a jockey can create an account.
      */
     @isTest

--- a/force-app/main/default/classes/DatabaseJockeyTest.cls
+++ b/force-app/main/default/classes/DatabaseJockeyTest.cls
@@ -53,4 +53,40 @@ private class DatabaseJockeyTest {
             'New jockey should not be the same as given jockey'
         );
     }
+
+    /**
+     * Confirm that a jockey can edit an account.
+     */
+    @isTest
+    private static void updateAccount() {
+
+        // Given
+        Account givenAcme = new Account(
+            Name = 'Acme, Inc. (TEST)'
+        );
+
+        insert givenAcme;
+
+        // When
+        Test.startTest();
+
+        Account newAcme = new Account(
+            Id = givenAcme.Id,
+            Name = 'Acme Corporation (TEST)'
+        );
+
+        DatabaseJockey jockey = DatabaseJockey.newInstance();
+
+        List<Database.SaveResult> results = jockey.upd(
+            new List<Account> { newAcme }
+        );
+
+        // Then
+        Test.stopTest();
+
+        System.assert(
+            results.get(0).isSuccess(),
+            'Update failed: ' + results.get(0).getErrors()
+        );
+    }
 }

--- a/force-app/main/default/classes/DatabaseJockeyTest.cls-meta.xml
+++ b/force-app/main/default/classes/DatabaseJockeyTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/SimpleStubProvider.cls
+++ b/force-app/main/default/classes/SimpleStubProvider.cls
@@ -1,0 +1,64 @@
+public without sharing virtual class SimpleStubProvider
+implements System.StubProvider {
+
+    public static List<MethodCall> calls = new List<MethodCall>();
+
+    protected virtual Object getReturnValue(MethodCall call) {
+        return null;
+    }
+
+    protected virtual Boolean hasReturnValue(MethodCall call) {
+        return true;
+    }
+
+    public Object handleMethodCall(
+        Object stubbedObject,
+        String stubbedMethodName,
+        System.Type returnType,
+        List<System.Type> listOfParamTypes,
+        List<String> listOfParamNames,
+        List<Object> listOfArgs
+    ) {
+        
+        // Construct the method call
+        MethodCall call = new MethodCall(
+            stubbedObject,
+            stubbedMethodName,
+            returnType,
+            listOfParamTypes,
+            listOfParamNames,
+            listOfArgs
+        );
+
+        // Log the method call
+        calls.add(call);
+        
+        // Return the default response or a custom response if one is specified
+        return this.hasReturnValue(call) ? this.getReturnValue(call) : null;
+    }
+
+    private class MethodCall {
+        public List<Object> args { get; set; }
+        public List<String> paramNames { get; set; }
+        public List<Type> paramTypes { get; set; }
+        public Type returnType { get; set; }
+        public Object stubbedObject { get; set; }
+        public String stubbedMethodName { get; set; }
+
+        public MethodCall(
+            Object stubbedObject,
+            String stubbedMethodName,
+            System.Type returnType,
+            List<System.Type> listOfParamTypes,
+            List<String> listOfParamNames,
+            List<Object> listOfArgs
+        ) {
+            this.stubbedObject = stubbedObject;
+            this.stubbedMethodName = stubbedMethodName;
+            this.returnType = returnType;
+            this.paramTypes = listOfParamTypes;
+            this.paramNames = listOfParamNames;
+            this.args = listOfArgs;
+        }
+    }
+}

--- a/force-app/main/default/classes/SimpleStubProvider.cls-meta.xml
+++ b/force-app/main/default/classes/SimpleStubProvider.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/SlackService.cls
+++ b/force-app/main/default/classes/SlackService.cls
@@ -15,6 +15,8 @@ public with sharing class SlackService {
      */
     public static Map<String, SlackService> instanceMap =
             new Map<String, SlackService>();
+    
+    private DatabaseJockey jockey;
 
     private String teamId;
 
@@ -29,9 +31,19 @@ public with sharing class SlackService {
     }
 
     public SlackService(String teamId, SlackApiService slackApi) {
+        this(teamId, slackApi, DatabaseJockey.newInstance());
+    }
+
+    @TestVisible
+    private SlackService(
+        String teamId,
+        SlackApiService slackApi,
+        DatabaseJockey jockey
+    ) {
         this.contactMap = new Map<String, Contact>();
         this.teamId = teamId;
         this.slackApi = slackApi;
+        this.jockey = jockey;
     }
 
     /**
@@ -68,7 +80,7 @@ public with sharing class SlackService {
                 Name = teamId,
                 SlackTeamId__c = teamId);
 
-        insert teamAccount;
+        this.jockey.ins(teamAccount);
         return teamAccount;
     }
 
@@ -84,7 +96,7 @@ public with sharing class SlackService {
                 TimeZoneSidKey__c = DEFAULT_TIME_ZONE_SID_KEY,
                 SlackUserId__c = userId);
 
-        insert userContact;
+        this.jockey.ins(userContact);
 
         // Set the reference object for convenient reference
         userContact.Account = teamAccount;
@@ -198,7 +210,7 @@ public with sharing class SlackService {
     public Account storeAccessToken(String accessToken, String teamId) {
         Account teamAccount = this.findOrCreateAccount(teamId);
         teamAccount.SlackAccessToken__c = accessToken;
-        update teamAccount;
+        this.jockey.upd(teamAccount);
         return teamAccount;
     }
 }

--- a/force-app/main/default/classes/SlackServiceTest.cls
+++ b/force-app/main/default/classes/SlackServiceTest.cls
@@ -18,6 +18,8 @@ private class SlackServiceTest {
         System.assertEquals(0, givenAccounts.size(),
                 'no existing accounts expected');
 
+        DatabaseJockey jockey = DatabaseJockeyMock.newInstance();
+
         // Stub the SlackApiService instance
         TestService.SlackApiServiceStubProvier slackApiStubProvider =
                 new TestService.SlackApiServiceStubProvier();
@@ -29,32 +31,24 @@ private class SlackServiceTest {
         // When
         Test.startTest();
 
-        SlackService slack = new SlackService(null, slackApi);
+        SlackService slack = new SlackService(null, slackApi, jockey);
 
         SlackApi.TeamInfoResponse teamInfo = slack.activateTeam('test');
 
         // then
         Test.stopTest();
-
-        List<Account> thenAccounts = [
-            SELECT
-                SlackAccessToken__c,
-                SlackTeamId__c,
-                Id
-            FROM Account
-        ];
-
-        System.assertEquals(1, thenAccounts.size(),
-                'one account should have been created');
+        
+        Account insertedAccount =
+                (Account)SimpleStubProvider.calls.get(0).args.get(0);
 
         System.assertEquals(
                 'test-access-token',
-                thenAccounts[0].SlackAccessToken__c,
+                insertedAccount.SlackAccessToken__c,
                 Schema.SObjectType.Account.fields.SlackAccessToken__c.label);
 
         System.assertEquals(
                 'test-team-id',
-                thenAccounts[0].SlackTeamId__c,
+                insertedAccount.SlackTeamId__c,
                 Schema.SObjectType.Account.fields.SlackTeamId__c.label);
     }
 


### PR DESCRIPTION
This pr introduces the `DatabaseJockey` class, which acts as a proxy for `Database` functions that perform DML operations. The class itself has minimal tests, and it comes with a related `DatabaseJockeyMock` which can be used when testing classes that have a dependency on `DatabaseJockey`.